### PR TITLE
Windows build update in master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Tutorial Samples
 ================
 A set of samples to illustrate Vulkan API on Android with Android Studio		
-Note: to build on windows, please use branch "build-windows" from this repo to temporarily workaround windows clang problem
+To build on windows for tutorial02, copy/install ndk-r12 ( or better ) to a directory close to root dir ( c: ) to workaround command path 260 character limit issue;see totorial02's build.gradle for details
 
 Other Resources:	
 Additional Android Studio/NDK samples:    

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Tutorial Samples
 ================
 A set of samples to illustrate Vulkan API on Android with Android Studio		
-To build on windows for tutorial02, copy/install ndk-r12 ( or better ) to a directory close to root dir ( c: ) to workaround command path 260 character limit issue;see totorial02's build.gradle for details
+To build on windows for tutorial02/03, copy/install ndk-r12 ( or better ) to a directory close to root dir ( c: ) to workaround command path 260 character limit issue;see totorial02/03's build.gradle for details
 
 Other Resources:	
 Additional Android Studio/NDK samples:    

--- a/tutorial01_load_vulkan/build.gradle
+++ b/tutorial01_load_vulkan/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-alpha5'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0-rc1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial02_prebuild_layers/app/build.gradle
+++ b/tutorial02_prebuild_layers/app/build.gradle
@@ -1,3 +1,4 @@
+import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.android.model.application'
 
 Properties properties = new Properties()
@@ -65,15 +66,19 @@ model {
     }
 }
 // ******** Adding validation layers into build *******
-// Build layers if necessary
-//    to build on windows(*), use "${ndkDir}/ndk-build.cmd" instead
+// Build layers if necessary: works for non-windows Host
+// For windows host, a couple extra steps must be done before build this project
+//   ndk-r12 ( or better ) command path exceed 260 character limit:
+//       to workaround it, copy your ndk to a place with shorter path like
+//           c:\ndk-r12
+//       and point your local.properties file's ndk.dir to the new location
+def ndkBuildCmd = "${ndkDir}/ndk-build"
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    ndkBuildCmd = "${ndkDir}/ndk-build.cmd"
+}
 task(buildLayers, type : Exec) {
     workingDir(valLayerSrc + "/build-android")
-    if(!file("${valLayerSrc}/build-android/libs").exists()) {
-        commandLine "${ndkDir}/ndk-build", "NDK_PROJECT_PATH=.", "-j", "8"
-    } else {
-        commandLine 'echo', 'Validation layer is already up to date'
-    }
+    commandLine "${ndkBuildCmd}", 'NDK_PROJECT_PATH=.', '-j', '8'
 }
 
 // Copy the validation layers

--- a/tutorial02_prebuild_layers/build.gradle
+++ b/tutorial02_prebuild_layers/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-alpha5'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0-rc1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial03_traceable_layers/README.md
+++ b/tutorial03_traceable_layers/README.md
@@ -4,5 +4,10 @@ Add gradle build for validation layers as app's jniLib dependencies
 so inaries are packed into APK automatically and traceale at run-time
 (layers could be stepped into when debugging application)
 Enable all validation layers/extensions found on the system
-Using vulkan wrappers in common/vulkan_wrapper directory
+Using vulkan wrappers in common/vulkan_wrapper directory	
+**Windows build extra steps**	
+if you see errors while building validation layers, try the following workaround:	
+- copy your ndk to be directly under c:\
+- configure your ndk.dir inside local.properties to your new ndk location
+this is due to the fact that commend path is above 260 when source is inside ndk
 

--- a/tutorial03_traceable_layers/app/build.gradle
+++ b/tutorial03_traceable_layers/app/build.gradle
@@ -50,6 +50,10 @@ model {
                         srcDir '../../common/vulkan_wrapper'
                     }
                 }
+                // To build on windows, must shorten the source directly path
+                // one way is to copy your ndk to c:\ directory [c:\ndk-r12], and confogure new location to ndk.dir in local.properties
+                // the other way is to just copy layers source out from ndk\sources\third_party\vulkan to c:\vulkan.
+                // Linux / Mac build should work as without any changes
                 jniLibs {
                     dependencies {
                         project ":threading"

--- a/tutorial03_traceable_layers/build.gradle
+++ b/tutorial03_traceable_layers/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-alpha5'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0-rc1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial04_first_window/build.gradle
+++ b/tutorial04_first_window/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-alpha5'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0-rc1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial05_triangle/build.gradle
+++ b/tutorial05_triangle/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.7.0-beta1'
+        classpath 'com.android.tools.build:gradle-experimental:0.7.0-rc1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
1) switch between ndk-build/ndk-build.cmd for non-windows / windows platform
2) add comment about layer source path too long on windows build, and also workaround options 