### PR TITLE
vulkan_wrapper enhancements

### DIFF
--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -11,12 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 // This file is handmade.
-
-#include <string.h>
-#include <vector>
-#include <stdio.h>
 
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
@@ -64,7 +59,8 @@ int InitVulkan(void) {
     // Set an hook to real vkCreateInstance
     vkCreateInstance_HOOK = (PFN_vkCreateInstance) (vkGetInstanceProcAddr(nullptr, "vkCreateInstance"));
     // point public vkCreateInstance to our delegate function
-    vkCreateInstance = &vkCreateInstanceDelegate;    
+    vkCreateInstance = &vkCreateInstanceDelegate;  
+    return 1;
 }
 
 /**

--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// This file is handmade.
 
 #include <string.h>
 #include <vector>
@@ -28,7 +29,6 @@
    #include <dlfcn.h>
 #endif
 
-static bool isInstanceLoaded = false;
 // a hook to Vulkan native function
 static PFN_vkCreateInstance vkCreateInstance_HOOK;
 
@@ -69,17 +69,18 @@ int InitVulkan(void) {
     if(!vkGetInstanceProcAddr)
 	   return 0;
 
-    //load basic functions required by  createInstance
+    //load the two basic functions required by VkCreateInstance
     vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties) (vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceExtensionProperties"));
     vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties) (vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceLayerProperties"));
-    // Set an hook to vkCreateInstance
+    // Set an hook to real vkCreateInstance
     vkCreateInstance_HOOK = (PFN_vkCreateInstance) (vkGetInstanceProcAddr(nullptr, "vkCreateInstance"));
     // point public vkCreateInstance to our delegate function
     vkCreateInstance = &vkCreateInstanceDelegate;    
 }
 
 /**
- * This functions intercepts vkCreateInstance and loads all Vulkan functions.
+ * Delegate function to vkCreateInstance
+ * This functions intercepts vkCreateInstance calls and loads all Vulkan functions.
  */
 VkResult vkCreateInstanceDelegate( const VkInstanceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator,
@@ -90,7 +91,7 @@ VkResult vkCreateInstanceDelegate( const VkInstanceCreateInfo* pCreateInfo,
     }	
     //Load VkInstance's related functions
     VkInstance instance = *pInstance;
-    LoadInstanceProcs(instance);	
+    LoadInstanceProcs(instance);    
     return res;
 }
 

--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -165,9 +165,9 @@ int InitInstanceProcs(VkInstance instance){
     vkGetDeviceProcAddr = (PFN_vkGetDeviceProcAddr)(vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr"));
     vkCreateDevice = (PFN_vkCreateDevice)(vkGetInstanceProcAddr(instance, "vkCreateDevice"));
     vkDestroyDevice = (PFN_vkDestroyDevice)(vkGetInstanceProcAddr(instance, "vkDestroyDevice"));
-    vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceExtensionProperties"));
+//  vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceExtensionProperties"));
     vkEnumerateDeviceExtensionProperties = (PFN_vkEnumerateDeviceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceExtensionProperties"));
-    vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceLayerProperties"));
+//  vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceLayerProperties"));
     vkEnumerateDeviceLayerProperties = (PFN_vkEnumerateDeviceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceLayerProperties"));
     vkGetDeviceQueue = (PFN_vkGetDeviceQueue)(vkGetInstanceProcAddr(instance, "vkGetDeviceQueue"));
     vkQueueSubmit = (PFN_vkQueueSubmit)(vkGetInstanceProcAddr(instance, "vkQueueSubmit"));

--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -21,13 +21,8 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 #include "vulkan_wrapper.h"
+#include <dlfcn.h>
 
-#ifdef _WIN32
-   #include <windows.h>
-   #include <wchar.h>
-#else
-   #include <dlfcn.h>
-#endif
 
 // a hook to Vulkan native function
 static PFN_vkCreateInstance vkCreateInstance_HOOK;

--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -51,15 +51,9 @@ int LoadInstanceProcs(VkInstance instance);
  * @return 0 if failed to init Vulkan
  */
 int InitVulkan(void) {
-#ifdef _WIN32
-    #define LoadProcAddress GetProcAddress
-    HINSTANCE  libvulkan = NULL;    
-    libvulkan = LoadLibrary("vulkan-1.dll");   
-#else  // all *nix
     #define LoadProcAddress dlsym
     void* libvulkan = nullptr;    
-    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	
-#endif    
+    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	  
     
     if (!libvulkan)
         return 0;
@@ -84,36 +78,12 @@ int InitVulkan(void) {
  */
 VkResult vkCreateInstanceDelegate( const VkInstanceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator,
-<<<<<<< HEAD
 			           VkInstance* pInstance){
     VkResult res = vkCreateInstance_HOOK(pCreateInfo, pAllocator, pInstance);    
-=======
-			           VkInstance* pInstance){	
-  VkResult res;  
-// EXPERIMENTAL - NOT FOR PRODUCTION !!  
-#ifdef VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT
-    // enable all extensions if there is not extensions enabled
-    if(pCreateInfo != NULL && (pCreateInfo->ppEnabledExtensionNames == NULL || pCreateInfo->enabledExtensionCount==0) ){
-        VkInstanceCreateInfo createInfo = *pCreateInfo;
-        createInfo.enabledExtensionCount = _extensionCount;
-        createInfo.ppEnabledExtensionNames = _ppExtensionNames;
-        printf("VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT 0x%p count: %d \n", _ppExtensionNames, _extensionCount );
-        res = vkCreateInstance_HOOK(&createInfo, pAllocator, pInstance);	
-    }else
-#endif	
-    {
-    // call Hook
-    res = vkCreateInstance_HOOK(pCreateInfo, pAllocator, pInstance);	
-    }
->>>>>>> origin/master
     if(res < 0){
 	return res;
     }	
-<<<<<<< HEAD
     //Load VkInstance's related functions
-=======
-    // Load ALL VkInstance related functions
->>>>>>> origin/master
     VkInstance instance = *pInstance;
     LoadInstanceProcs(instance);    
     return res;

--- a/common/vulkan_wrapper/vulkan_wrapper.cpp
+++ b/common/vulkan_wrapper/vulkan_wrapper.cpp
@@ -15,205 +15,278 @@
 #include "vulkan_wrapper.h"
 #include <dlfcn.h>
 
+void* libvulkan = nullptr;
+
 int InitVulkan(void) {
-    void* libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	
     if (!libvulkan)
         return 0;
+	// the only function loaded using dlsym	
+	vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libvulkan, "vkGetInstanceProcAddr"));	
+	
+	if(!vkGetInstanceProcAddr)
+	   return 0;
+	
+	//load basic functions required to call vkCreateInstance
+	vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties) (vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceExtensionProperties"));    
+    vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties) (vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceLayerProperties"));	
+    vkCreateInstance_HOOK = (PFN_vkCreateInstance)(vkGetInstanceProcAddr(NULL, "vkCreateInstance"));	
+	
+	// get extension names 
+	availableExtensionsCount = 0;
+	vkEnumerateInstanceExtensionProperties(NULL,&availableExtensionsCount,NULL);
+	ppAvailableExtensions = new char[availableExtensionsCount][VK_MAX_EXTENSION_NAME_SIZE];
+	VkExtensionProperties* extProps = new VkExtensionProperties[availableExtensionsCount];
+	  vkEnumerateInstanceExtensionProperties(NULL,&availableExtensionsCount,extProps);
+	  for(uint32_t i=0; i < availableExtensionsCount; i++){
+         strcpy(ppAvailableExtensions[i], extProps[i].extensionName);
+	  }	  
+	delete[] extProps;
+	
+	// get layers names
+	availableLayersCount = 0;
+	vkEnumerateInstanceLayerProperties(NULL,&availableLayersCount,NULL);
+	ppAvailableLayers = new char[availableLayersCount][VK_MAX_EXTENSION_NAME_SIZE];  // layerName[VK_MAX_EXTENSION_NAME_SIZE]
+	VkLayerProperties* layProps = new VkLayerProperties[availableLayersCount];
+	  vkEnumerateInstanceLayerProperties(NULL,&availableLayersCount,layProps);
+	  for(uint32_t i=0; i < availableLayersCount; i++){
+         strcpy(ppAvailableLayers[i], layProps[i].layerName);
+	  }	  
+	delete[] layProps;
+	
+}
 
-    // Vulkan supported, set function addresses
-    vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(dlsym(libvulkan, "vkCreateInstance"));
-    vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(dlsym(libvulkan, "vkDestroyInstance"));
-    vkEnumeratePhysicalDevices = reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(dlsym(libvulkan, "vkEnumeratePhysicalDevices"));
-    vkGetPhysicalDeviceFeatures = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures>(dlsym(libvulkan, "vkGetPhysicalDeviceFeatures"));
-    vkGetPhysicalDeviceFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceFormatProperties"));
-    vkGetPhysicalDeviceImageFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceImageFormatProperties"));
-    vkGetPhysicalDeviceProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceProperties"));
-    vkGetPhysicalDeviceQueueFamilyProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceQueueFamilyProperties"));
-    vkGetPhysicalDeviceMemoryProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceMemoryProperties"));
-    vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libvulkan, "vkGetInstanceProcAddr"));
-    vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(dlsym(libvulkan, "vkGetDeviceProcAddr"));
-    vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(dlsym(libvulkan, "vkCreateDevice"));
-    vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(dlsym(libvulkan, "vkDestroyDevice"));
-    vkEnumerateInstanceExtensionProperties = reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(dlsym(libvulkan, "vkEnumerateInstanceExtensionProperties"));
-    vkEnumerateDeviceExtensionProperties = reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(dlsym(libvulkan, "vkEnumerateDeviceExtensionProperties"));
-    vkEnumerateInstanceLayerProperties = reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(dlsym(libvulkan, "vkEnumerateInstanceLayerProperties"));
-    vkEnumerateDeviceLayerProperties = reinterpret_cast<PFN_vkEnumerateDeviceLayerProperties>(dlsym(libvulkan, "vkEnumerateDeviceLayerProperties"));
-    vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(dlsym(libvulkan, "vkGetDeviceQueue"));
-    vkQueueSubmit = reinterpret_cast<PFN_vkQueueSubmit>(dlsym(libvulkan, "vkQueueSubmit"));
-    vkQueueWaitIdle = reinterpret_cast<PFN_vkQueueWaitIdle>(dlsym(libvulkan, "vkQueueWaitIdle"));
-    vkDeviceWaitIdle = reinterpret_cast<PFN_vkDeviceWaitIdle>(dlsym(libvulkan, "vkDeviceWaitIdle"));
-    vkAllocateMemory = reinterpret_cast<PFN_vkAllocateMemory>(dlsym(libvulkan, "vkAllocateMemory"));
-    vkFreeMemory = reinterpret_cast<PFN_vkFreeMemory>(dlsym(libvulkan, "vkFreeMemory"));
-    vkMapMemory = reinterpret_cast<PFN_vkMapMemory>(dlsym(libvulkan, "vkMapMemory"));
-    vkUnmapMemory = reinterpret_cast<PFN_vkUnmapMemory>(dlsym(libvulkan, "vkUnmapMemory"));
-    vkFlushMappedMemoryRanges = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(dlsym(libvulkan, "vkFlushMappedMemoryRanges"));
-    vkInvalidateMappedMemoryRanges = reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(dlsym(libvulkan, "vkInvalidateMappedMemoryRanges"));
-    vkGetDeviceMemoryCommitment = reinterpret_cast<PFN_vkGetDeviceMemoryCommitment>(dlsym(libvulkan, "vkGetDeviceMemoryCommitment"));
-    vkBindBufferMemory = reinterpret_cast<PFN_vkBindBufferMemory>(dlsym(libvulkan, "vkBindBufferMemory"));
-    vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(dlsym(libvulkan, "vkBindImageMemory"));
-    vkGetBufferMemoryRequirements = reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(dlsym(libvulkan, "vkGetBufferMemoryRequirements"));
-    vkGetImageMemoryRequirements = reinterpret_cast<PFN_vkGetImageMemoryRequirements>(dlsym(libvulkan, "vkGetImageMemoryRequirements"));
-    vkGetImageSparseMemoryRequirements = reinterpret_cast<PFN_vkGetImageSparseMemoryRequirements>(dlsym(libvulkan, "vkGetImageSparseMemoryRequirements"));
-    vkGetPhysicalDeviceSparseImageFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceSparseImageFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceSparseImageFormatProperties"));
-    vkQueueBindSparse = reinterpret_cast<PFN_vkQueueBindSparse>(dlsym(libvulkan, "vkQueueBindSparse"));
-    vkCreateFence = reinterpret_cast<PFN_vkCreateFence>(dlsym(libvulkan, "vkCreateFence"));
-    vkDestroyFence = reinterpret_cast<PFN_vkDestroyFence>(dlsym(libvulkan, "vkDestroyFence"));
-    vkResetFences = reinterpret_cast<PFN_vkResetFences>(dlsym(libvulkan, "vkResetFences"));
-    vkGetFenceStatus = reinterpret_cast<PFN_vkGetFenceStatus>(dlsym(libvulkan, "vkGetFenceStatus"));
-    vkWaitForFences = reinterpret_cast<PFN_vkWaitForFences>(dlsym(libvulkan, "vkWaitForFences"));
-    vkCreateSemaphore = reinterpret_cast<PFN_vkCreateSemaphore>(dlsym(libvulkan, "vkCreateSemaphore"));
-    vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(dlsym(libvulkan, "vkDestroySemaphore"));
-    vkCreateEvent = reinterpret_cast<PFN_vkCreateEvent>(dlsym(libvulkan, "vkCreateEvent"));
-    vkDestroyEvent = reinterpret_cast<PFN_vkDestroyEvent>(dlsym(libvulkan, "vkDestroyEvent"));
-    vkGetEventStatus = reinterpret_cast<PFN_vkGetEventStatus>(dlsym(libvulkan, "vkGetEventStatus"));
-    vkSetEvent = reinterpret_cast<PFN_vkSetEvent>(dlsym(libvulkan, "vkSetEvent"));
-    vkResetEvent = reinterpret_cast<PFN_vkResetEvent>(dlsym(libvulkan, "vkResetEvent"));
-    vkCreateQueryPool = reinterpret_cast<PFN_vkCreateQueryPool>(dlsym(libvulkan, "vkCreateQueryPool"));
-    vkDestroyQueryPool = reinterpret_cast<PFN_vkDestroyQueryPool>(dlsym(libvulkan, "vkDestroyQueryPool"));
-    vkGetQueryPoolResults = reinterpret_cast<PFN_vkGetQueryPoolResults>(dlsym(libvulkan, "vkGetQueryPoolResults"));
-    vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(dlsym(libvulkan, "vkCreateBuffer"));
-    vkDestroyBuffer = reinterpret_cast<PFN_vkDestroyBuffer>(dlsym(libvulkan, "vkDestroyBuffer"));
-    vkCreateBufferView = reinterpret_cast<PFN_vkCreateBufferView>(dlsym(libvulkan, "vkCreateBufferView"));
-    vkDestroyBufferView = reinterpret_cast<PFN_vkDestroyBufferView>(dlsym(libvulkan, "vkDestroyBufferView"));
-    vkCreateImage = reinterpret_cast<PFN_vkCreateImage>(dlsym(libvulkan, "vkCreateImage"));
-    vkDestroyImage = reinterpret_cast<PFN_vkDestroyImage>(dlsym(libvulkan, "vkDestroyImage"));
-    vkGetImageSubresourceLayout = reinterpret_cast<PFN_vkGetImageSubresourceLayout>(dlsym(libvulkan, "vkGetImageSubresourceLayout"));
-    vkCreateImageView = reinterpret_cast<PFN_vkCreateImageView>(dlsym(libvulkan, "vkCreateImageView"));
-    vkDestroyImageView = reinterpret_cast<PFN_vkDestroyImageView>(dlsym(libvulkan, "vkDestroyImageView"));
-    vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(dlsym(libvulkan, "vkCreateShaderModule"));
-    vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(dlsym(libvulkan, "vkDestroyShaderModule"));
-    vkCreatePipelineCache = reinterpret_cast<PFN_vkCreatePipelineCache>(dlsym(libvulkan, "vkCreatePipelineCache"));
-    vkDestroyPipelineCache = reinterpret_cast<PFN_vkDestroyPipelineCache>(dlsym(libvulkan, "vkDestroyPipelineCache"));
-    vkGetPipelineCacheData = reinterpret_cast<PFN_vkGetPipelineCacheData>(dlsym(libvulkan, "vkGetPipelineCacheData"));
-    vkMergePipelineCaches = reinterpret_cast<PFN_vkMergePipelineCaches>(dlsym(libvulkan, "vkMergePipelineCaches"));
-    vkCreateGraphicsPipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(dlsym(libvulkan, "vkCreateGraphicsPipelines"));
-    vkCreateComputePipelines = reinterpret_cast<PFN_vkCreateComputePipelines>(dlsym(libvulkan, "vkCreateComputePipelines"));
-    vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(dlsym(libvulkan, "vkDestroyPipeline"));
-    vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(dlsym(libvulkan, "vkCreatePipelineLayout"));
-    vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(dlsym(libvulkan, "vkDestroyPipelineLayout"));
-    vkCreateSampler = reinterpret_cast<PFN_vkCreateSampler>(dlsym(libvulkan, "vkCreateSampler"));
-    vkDestroySampler = reinterpret_cast<PFN_vkDestroySampler>(dlsym(libvulkan, "vkDestroySampler"));
-    vkCreateDescriptorSetLayout = reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(dlsym(libvulkan, "vkCreateDescriptorSetLayout"));
-    vkDestroyDescriptorSetLayout = reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(dlsym(libvulkan, "vkDestroyDescriptorSetLayout"));
-    vkCreateDescriptorPool = reinterpret_cast<PFN_vkCreateDescriptorPool>(dlsym(libvulkan, "vkCreateDescriptorPool"));
-    vkDestroyDescriptorPool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(dlsym(libvulkan, "vkDestroyDescriptorPool"));
-    vkResetDescriptorPool = reinterpret_cast<PFN_vkResetDescriptorPool>(dlsym(libvulkan, "vkResetDescriptorPool"));
-    vkAllocateDescriptorSets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(dlsym(libvulkan, "vkAllocateDescriptorSets"));
-    vkFreeDescriptorSets = reinterpret_cast<PFN_vkFreeDescriptorSets>(dlsym(libvulkan, "vkFreeDescriptorSets"));
-    vkUpdateDescriptorSets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(dlsym(libvulkan, "vkUpdateDescriptorSets"));
-    vkCreateFramebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(dlsym(libvulkan, "vkCreateFramebuffer"));
-    vkDestroyFramebuffer = reinterpret_cast<PFN_vkDestroyFramebuffer>(dlsym(libvulkan, "vkDestroyFramebuffer"));
-    vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(dlsym(libvulkan, "vkCreateRenderPass"));
-    vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(dlsym(libvulkan, "vkDestroyRenderPass"));
-    vkGetRenderAreaGranularity = reinterpret_cast<PFN_vkGetRenderAreaGranularity>(dlsym(libvulkan, "vkGetRenderAreaGranularity"));
-    vkCreateCommandPool = reinterpret_cast<PFN_vkCreateCommandPool>(dlsym(libvulkan, "vkCreateCommandPool"));
-    vkDestroyCommandPool = reinterpret_cast<PFN_vkDestroyCommandPool>(dlsym(libvulkan, "vkDestroyCommandPool"));
-    vkResetCommandPool = reinterpret_cast<PFN_vkResetCommandPool>(dlsym(libvulkan, "vkResetCommandPool"));
-    vkAllocateCommandBuffers = reinterpret_cast<PFN_vkAllocateCommandBuffers>(dlsym(libvulkan, "vkAllocateCommandBuffers"));
-    vkFreeCommandBuffers = reinterpret_cast<PFN_vkFreeCommandBuffers>(dlsym(libvulkan, "vkFreeCommandBuffers"));
-    vkBeginCommandBuffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(dlsym(libvulkan, "vkBeginCommandBuffer"));
-    vkEndCommandBuffer = reinterpret_cast<PFN_vkEndCommandBuffer>(dlsym(libvulkan, "vkEndCommandBuffer"));
-    vkResetCommandBuffer = reinterpret_cast<PFN_vkResetCommandBuffer>(dlsym(libvulkan, "vkResetCommandBuffer"));
-    vkCmdBindPipeline = reinterpret_cast<PFN_vkCmdBindPipeline>(dlsym(libvulkan, "vkCmdBindPipeline"));
-    vkCmdSetViewport = reinterpret_cast<PFN_vkCmdSetViewport>(dlsym(libvulkan, "vkCmdSetViewport"));
-    vkCmdSetScissor = reinterpret_cast<PFN_vkCmdSetScissor>(dlsym(libvulkan, "vkCmdSetScissor"));
-    vkCmdSetLineWidth = reinterpret_cast<PFN_vkCmdSetLineWidth>(dlsym(libvulkan, "vkCmdSetLineWidth"));
-    vkCmdSetDepthBias = reinterpret_cast<PFN_vkCmdSetDepthBias>(dlsym(libvulkan, "vkCmdSetDepthBias"));
-    vkCmdSetBlendConstants = reinterpret_cast<PFN_vkCmdSetBlendConstants>(dlsym(libvulkan, "vkCmdSetBlendConstants"));
-    vkCmdSetDepthBounds = reinterpret_cast<PFN_vkCmdSetDepthBounds>(dlsym(libvulkan, "vkCmdSetDepthBounds"));
-    vkCmdSetStencilCompareMask = reinterpret_cast<PFN_vkCmdSetStencilCompareMask>(dlsym(libvulkan, "vkCmdSetStencilCompareMask"));
-    vkCmdSetStencilWriteMask = reinterpret_cast<PFN_vkCmdSetStencilWriteMask>(dlsym(libvulkan, "vkCmdSetStencilWriteMask"));
-    vkCmdSetStencilReference = reinterpret_cast<PFN_vkCmdSetStencilReference>(dlsym(libvulkan, "vkCmdSetStencilReference"));
-    vkCmdBindDescriptorSets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(dlsym(libvulkan, "vkCmdBindDescriptorSets"));
-    vkCmdBindIndexBuffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(dlsym(libvulkan, "vkCmdBindIndexBuffer"));
-    vkCmdBindVertexBuffers = reinterpret_cast<PFN_vkCmdBindVertexBuffers>(dlsym(libvulkan, "vkCmdBindVertexBuffers"));
-    vkCmdDraw = reinterpret_cast<PFN_vkCmdDraw>(dlsym(libvulkan, "vkCmdDraw"));
-    vkCmdDrawIndexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(dlsym(libvulkan, "vkCmdDrawIndexed"));
-    vkCmdDrawIndirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(dlsym(libvulkan, "vkCmdDrawIndirect"));
-    vkCmdDrawIndexedIndirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(dlsym(libvulkan, "vkCmdDrawIndexedIndirect"));
-    vkCmdDispatch = reinterpret_cast<PFN_vkCmdDispatch>(dlsym(libvulkan, "vkCmdDispatch"));
-    vkCmdDispatchIndirect = reinterpret_cast<PFN_vkCmdDispatchIndirect>(dlsym(libvulkan, "vkCmdDispatchIndirect"));
-    vkCmdCopyBuffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(dlsym(libvulkan, "vkCmdCopyBuffer"));
-    vkCmdCopyImage = reinterpret_cast<PFN_vkCmdCopyImage>(dlsym(libvulkan, "vkCmdCopyImage"));
-    vkCmdBlitImage = reinterpret_cast<PFN_vkCmdBlitImage>(dlsym(libvulkan, "vkCmdBlitImage"));
-    vkCmdCopyBufferToImage = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(dlsym(libvulkan, "vkCmdCopyBufferToImage"));
-    vkCmdCopyImageToBuffer = reinterpret_cast<PFN_vkCmdCopyImageToBuffer>(dlsym(libvulkan, "vkCmdCopyImageToBuffer"));
-    vkCmdUpdateBuffer = reinterpret_cast<PFN_vkCmdUpdateBuffer>(dlsym(libvulkan, "vkCmdUpdateBuffer"));
-    vkCmdFillBuffer = reinterpret_cast<PFN_vkCmdFillBuffer>(dlsym(libvulkan, "vkCmdFillBuffer"));
-    vkCmdClearColorImage = reinterpret_cast<PFN_vkCmdClearColorImage>(dlsym(libvulkan, "vkCmdClearColorImage"));
-    vkCmdClearDepthStencilImage = reinterpret_cast<PFN_vkCmdClearDepthStencilImage>(dlsym(libvulkan, "vkCmdClearDepthStencilImage"));
-    vkCmdClearAttachments = reinterpret_cast<PFN_vkCmdClearAttachments>(dlsym(libvulkan, "vkCmdClearAttachments"));
-    vkCmdResolveImage = reinterpret_cast<PFN_vkCmdResolveImage>(dlsym(libvulkan, "vkCmdResolveImage"));
-    vkCmdSetEvent = reinterpret_cast<PFN_vkCmdSetEvent>(dlsym(libvulkan, "vkCmdSetEvent"));
-    vkCmdResetEvent = reinterpret_cast<PFN_vkCmdResetEvent>(dlsym(libvulkan, "vkCmdResetEvent"));
-    vkCmdWaitEvents = reinterpret_cast<PFN_vkCmdWaitEvents>(dlsym(libvulkan, "vkCmdWaitEvents"));
-    vkCmdPipelineBarrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(dlsym(libvulkan, "vkCmdPipelineBarrier"));
-    vkCmdBeginQuery = reinterpret_cast<PFN_vkCmdBeginQuery>(dlsym(libvulkan, "vkCmdBeginQuery"));
-    vkCmdEndQuery = reinterpret_cast<PFN_vkCmdEndQuery>(dlsym(libvulkan, "vkCmdEndQuery"));
-    vkCmdResetQueryPool = reinterpret_cast<PFN_vkCmdResetQueryPool>(dlsym(libvulkan, "vkCmdResetQueryPool"));
-    vkCmdWriteTimestamp = reinterpret_cast<PFN_vkCmdWriteTimestamp>(dlsym(libvulkan, "vkCmdWriteTimestamp"));
-    vkCmdCopyQueryPoolResults = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(dlsym(libvulkan, "vkCmdCopyQueryPoolResults"));
-    vkCmdPushConstants = reinterpret_cast<PFN_vkCmdPushConstants>(dlsym(libvulkan, "vkCmdPushConstants"));
-    vkCmdBeginRenderPass = reinterpret_cast<PFN_vkCmdBeginRenderPass>(dlsym(libvulkan, "vkCmdBeginRenderPass"));
-    vkCmdNextSubpass = reinterpret_cast<PFN_vkCmdNextSubpass>(dlsym(libvulkan, "vkCmdNextSubpass"));
-    vkCmdEndRenderPass = reinterpret_cast<PFN_vkCmdEndRenderPass>(dlsym(libvulkan, "vkCmdEndRenderPass"));
-    vkCmdExecuteCommands = reinterpret_cast<PFN_vkCmdExecuteCommands>(dlsym(libvulkan, "vkCmdExecuteCommands"));
-    vkDestroySurfaceKHR = reinterpret_cast<PFN_vkDestroySurfaceKHR>(dlsym(libvulkan, "vkDestroySurfaceKHR"));
-    vkGetPhysicalDeviceSurfaceSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceSupportKHR"));
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
-    vkGetPhysicalDeviceSurfaceFormatsKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceFormatsKHR"));
-    vkGetPhysicalDeviceSurfacePresentModesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfacePresentModesKHR"));
-    vkCreateSwapchainKHR = reinterpret_cast<PFN_vkCreateSwapchainKHR>(dlsym(libvulkan, "vkCreateSwapchainKHR"));
-    vkDestroySwapchainKHR = reinterpret_cast<PFN_vkDestroySwapchainKHR>(dlsym(libvulkan, "vkDestroySwapchainKHR"));
-    vkGetSwapchainImagesKHR = reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(dlsym(libvulkan, "vkGetSwapchainImagesKHR"));
-    vkAcquireNextImageKHR = reinterpret_cast<PFN_vkAcquireNextImageKHR>(dlsym(libvulkan, "vkAcquireNextImageKHR"));
-    vkQueuePresentKHR = reinterpret_cast<PFN_vkQueuePresentKHR>(dlsym(libvulkan, "vkQueuePresentKHR"));
-    vkGetPhysicalDeviceDisplayPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPropertiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceDisplayPropertiesKHR"));
-    vkGetPhysicalDeviceDisplayPlanePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
-    vkGetDisplayPlaneSupportedDisplaysKHR = reinterpret_cast<PFN_vkGetDisplayPlaneSupportedDisplaysKHR>(dlsym(libvulkan, "vkGetDisplayPlaneSupportedDisplaysKHR"));
-    vkGetDisplayModePropertiesKHR = reinterpret_cast<PFN_vkGetDisplayModePropertiesKHR>(dlsym(libvulkan, "vkGetDisplayModePropertiesKHR"));
-    vkCreateDisplayModeKHR = reinterpret_cast<PFN_vkCreateDisplayModeKHR>(dlsym(libvulkan, "vkCreateDisplayModeKHR"));
-    vkGetDisplayPlaneCapabilitiesKHR = reinterpret_cast<PFN_vkGetDisplayPlaneCapabilitiesKHR>(dlsym(libvulkan, "vkGetDisplayPlaneCapabilitiesKHR"));
-    vkCreateDisplayPlaneSurfaceKHR = reinterpret_cast<PFN_vkCreateDisplayPlaneSurfaceKHR>(dlsym(libvulkan, "vkCreateDisplayPlaneSurfaceKHR"));
-    vkCreateSharedSwapchainsKHR = reinterpret_cast<PFN_vkCreateSharedSwapchainsKHR>(dlsym(libvulkan, "vkCreateSharedSwapchainsKHR"));
+/**
+ * This functions intercepts vkCreateInstance, in order to load all Instance related procedures
+ */
+VkResult vkCreateInstance( const VkInstanceCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator,
+						   VkInstance* pInstance){	
+	#ifdef VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT
+	 // enable all extensions
+	  if(pCreateInfo != NULL && pCreateInfo. ){
+	  
+	  }
+	#endif					   
+						   
+	// call Hook
+	VkResult res = vkCreateInstance_HOOK(pCreateInfo, pAllocator, pInstance);	
+	if(res<0){
+	  return res;
+	}	
+	// load VkInstance related functions
+	VkInstance instance = *pInstance;
+	if(!isInstanceLoaded){
+    	InitInstanceProcs(instance);	
+		isInstanceLoaded = true;
+	}
+	// create Hook to vkCreateVkDevice()
+	vkCreateDevice_HOOK =  (PFN_vkCreateDevice) (vkGetInstanceProcAddr(instance, "vkCreateDevice"));	
+	return res;
+}
+
+/**
+ * This function loads all related VKInstance functions
+ * @param instance - non null VkInstance to load 
+ */
+int InitInstanceProcs(VkInstance instance){
+		if(!instance)
+		   return 0;
+		
+    
+    vkDestroyInstance = (PFN_vkDestroyInstance)(vkGetInstanceProcAddr(instance, "vkDestroyInstance"));
+    vkEnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)(vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices"));
+    vkGetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures"));
+    vkGetPhysicalDeviceFormatProperties = (PFN_vkGetPhysicalDeviceFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties"));
+    vkGetPhysicalDeviceImageFormatProperties = (PFN_vkGetPhysicalDeviceImageFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceImageFormatProperties"));
+    vkGetPhysicalDeviceProperties = (PFN_vkGetPhysicalDeviceProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties"));
+    vkGetPhysicalDeviceQueueFamilyProperties = (PFN_vkGetPhysicalDeviceQueueFamilyProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyProperties"));
+    vkGetPhysicalDeviceMemoryProperties = (PFN_vkGetPhysicalDeviceMemoryProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMemoryProperties"));
+    vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(vkGetInstanceProcAddr(instance, "vkGetInstanceProcAddr"));
+    vkGetDeviceProcAddr = (PFN_vkGetDeviceProcAddr)(vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr"));
+    vkCreateDevice = (PFN_vkCreateDevice)(vkGetInstanceProcAddr(instance, "vkCreateDevice"));
+    vkDestroyDevice = (PFN_vkDestroyDevice)(vkGetInstanceProcAddr(instance, "vkDestroyDevice"));
+ 
+    vkEnumerateDeviceExtensionProperties = (PFN_vkEnumerateDeviceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceExtensionProperties"));
+
+    vkEnumerateDeviceLayerProperties = (PFN_vkEnumerateDeviceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceLayerProperties"));
+    vkGetDeviceQueue = (PFN_vkGetDeviceQueue)(vkGetInstanceProcAddr(instance, "vkGetDeviceQueue"));
+    vkQueueSubmit = (PFN_vkQueueSubmit)(vkGetInstanceProcAddr(instance, "vkQueueSubmit"));
+    vkQueueWaitIdle = (PFN_vkQueueWaitIdle)(vkGetInstanceProcAddr(instance, "vkQueueWaitIdle"));
+    vkDeviceWaitIdle = (PFN_vkDeviceWaitIdle)(vkGetInstanceProcAddr(instance, "vkDeviceWaitIdle"));
+    vkAllocateMemory = (PFN_vkAllocateMemory)(vkGetInstanceProcAddr(instance, "vkAllocateMemory"));
+    vkFreeMemory = (PFN_vkFreeMemory)(vkGetInstanceProcAddr(instance, "vkFreeMemory"));
+    vkMapMemory = (PFN_vkMapMemory)(vkGetInstanceProcAddr(instance, "vkMapMemory"));
+    vkUnmapMemory = (PFN_vkUnmapMemory)(vkGetInstanceProcAddr(instance, "vkUnmapMemory"));
+    vkFlushMappedMemoryRanges = (PFN_vkFlushMappedMemoryRanges)(vkGetInstanceProcAddr(instance, "vkFlushMappedMemoryRanges"));
+    vkInvalidateMappedMemoryRanges = (PFN_vkInvalidateMappedMemoryRanges)(vkGetInstanceProcAddr(instance, "vkInvalidateMappedMemoryRanges"));
+    vkGetDeviceMemoryCommitment = (PFN_vkGetDeviceMemoryCommitment)(vkGetInstanceProcAddr(instance, "vkGetDeviceMemoryCommitment"));
+    vkBindBufferMemory = (PFN_vkBindBufferMemory)(vkGetInstanceProcAddr(instance, "vkBindBufferMemory"));
+    vkBindImageMemory = (PFN_vkBindImageMemory)(vkGetInstanceProcAddr(instance, "vkBindImageMemory"));
+    vkGetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetBufferMemoryRequirements"));
+    vkGetImageMemoryRequirements = (PFN_vkGetImageMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetImageMemoryRequirements"));
+    vkGetImageSparseMemoryRequirements = (PFN_vkGetImageSparseMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetImageSparseMemoryRequirements"));
+    vkGetPhysicalDeviceSparseImageFormatProperties = (PFN_vkGetPhysicalDeviceSparseImageFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSparseImageFormatProperties"));
+    vkQueueBindSparse = (PFN_vkQueueBindSparse)(vkGetInstanceProcAddr(instance, "vkQueueBindSparse"));
+    vkCreateFence = (PFN_vkCreateFence)(vkGetInstanceProcAddr(instance, "vkCreateFence"));
+    vkDestroyFence = (PFN_vkDestroyFence)(vkGetInstanceProcAddr(instance, "vkDestroyFence"));
+    vkResetFences = (PFN_vkResetFences)(vkGetInstanceProcAddr(instance, "vkResetFences"));
+    vkGetFenceStatus = (PFN_vkGetFenceStatus)(vkGetInstanceProcAddr(instance, "vkGetFenceStatus"));
+    vkWaitForFences = (PFN_vkWaitForFences)(vkGetInstanceProcAddr(instance, "vkWaitForFences"));
+    vkCreateSemaphore = (PFN_vkCreateSemaphore)(vkGetInstanceProcAddr(instance, "vkCreateSemaphore"));
+    vkDestroySemaphore = (PFN_vkDestroySemaphore)(vkGetInstanceProcAddr(instance, "vkDestroySemaphore"));
+    vkCreateEvent = (PFN_vkCreateEvent)(vkGetInstanceProcAddr(instance, "vkCreateEvent"));
+    vkDestroyEvent = (PFN_vkDestroyEvent)(vkGetInstanceProcAddr(instance, "vkDestroyEvent"));
+    vkGetEventStatus = (PFN_vkGetEventStatus)(vkGetInstanceProcAddr(instance, "vkGetEventStatus"));
+    vkSetEvent = (PFN_vkSetEvent)(vkGetInstanceProcAddr(instance, "vkSetEvent"));
+    vkResetEvent = (PFN_vkResetEvent)(vkGetInstanceProcAddr(instance, "vkResetEvent"));
+    vkCreateQueryPool = (PFN_vkCreateQueryPool)(vkGetInstanceProcAddr(instance, "vkCreateQueryPool"));
+    vkDestroyQueryPool = (PFN_vkDestroyQueryPool)(vkGetInstanceProcAddr(instance, "vkDestroyQueryPool"));
+    vkGetQueryPoolResults = (PFN_vkGetQueryPoolResults)(vkGetInstanceProcAddr(instance, "vkGetQueryPoolResults"));
+    vkCreateBuffer = (PFN_vkCreateBuffer)(vkGetInstanceProcAddr(instance, "vkCreateBuffer"));
+    vkDestroyBuffer = (PFN_vkDestroyBuffer)(vkGetInstanceProcAddr(instance, "vkDestroyBuffer"));
+    vkCreateBufferView = (PFN_vkCreateBufferView)(vkGetInstanceProcAddr(instance, "vkCreateBufferView"));
+    vkDestroyBufferView = (PFN_vkDestroyBufferView)(vkGetInstanceProcAddr(instance, "vkDestroyBufferView"));
+    vkCreateImage = (PFN_vkCreateImage)(vkGetInstanceProcAddr(instance, "vkCreateImage"));
+    vkDestroyImage = (PFN_vkDestroyImage)(vkGetInstanceProcAddr(instance, "vkDestroyImage"));
+    vkGetImageSubresourceLayout = (PFN_vkGetImageSubresourceLayout)(vkGetInstanceProcAddr(instance, "vkGetImageSubresourceLayout"));
+    vkCreateImageView = (PFN_vkCreateImageView)(vkGetInstanceProcAddr(instance, "vkCreateImageView"));
+    vkDestroyImageView = (PFN_vkDestroyImageView)(vkGetInstanceProcAddr(instance, "vkDestroyImageView"));
+    vkCreateShaderModule = (PFN_vkCreateShaderModule)(vkGetInstanceProcAddr(instance, "vkCreateShaderModule"));
+    vkDestroyShaderModule = (PFN_vkDestroyShaderModule)(vkGetInstanceProcAddr(instance, "vkDestroyShaderModule"));
+    vkCreatePipelineCache = (PFN_vkCreatePipelineCache)(vkGetInstanceProcAddr(instance, "vkCreatePipelineCache"));
+    vkDestroyPipelineCache = (PFN_vkDestroyPipelineCache)(vkGetInstanceProcAddr(instance, "vkDestroyPipelineCache"));
+    vkGetPipelineCacheData = (PFN_vkGetPipelineCacheData)(vkGetInstanceProcAddr(instance, "vkGetPipelineCacheData"));
+    vkMergePipelineCaches = (PFN_vkMergePipelineCaches)(vkGetInstanceProcAddr(instance, "vkMergePipelineCaches"));
+    vkCreateGraphicsPipelines = (PFN_vkCreateGraphicsPipelines)(vkGetInstanceProcAddr(instance, "vkCreateGraphicsPipelines"));
+    vkCreateComputePipelines = (PFN_vkCreateComputePipelines)(vkGetInstanceProcAddr(instance, "vkCreateComputePipelines"));
+    vkDestroyPipeline = (PFN_vkDestroyPipeline)(vkGetInstanceProcAddr(instance, "vkDestroyPipeline"));
+    vkCreatePipelineLayout = (PFN_vkCreatePipelineLayout)(vkGetInstanceProcAddr(instance, "vkCreatePipelineLayout"));
+    vkDestroyPipelineLayout = (PFN_vkDestroyPipelineLayout)(vkGetInstanceProcAddr(instance, "vkDestroyPipelineLayout"));
+    vkCreateSampler = (PFN_vkCreateSampler)(vkGetInstanceProcAddr(instance, "vkCreateSampler"));
+    vkDestroySampler = (PFN_vkDestroySampler)(vkGetInstanceProcAddr(instance, "vkDestroySampler"));
+    vkCreateDescriptorSetLayout = (PFN_vkCreateDescriptorSetLayout)(vkGetInstanceProcAddr(instance, "vkCreateDescriptorSetLayout"));
+    vkDestroyDescriptorSetLayout = (PFN_vkDestroyDescriptorSetLayout)(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorSetLayout"));
+    vkCreateDescriptorPool = (PFN_vkCreateDescriptorPool)(vkGetInstanceProcAddr(instance, "vkCreateDescriptorPool"));
+    vkDestroyDescriptorPool = (PFN_vkDestroyDescriptorPool)(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorPool"));
+    vkResetDescriptorPool = (PFN_vkResetDescriptorPool)(vkGetInstanceProcAddr(instance, "vkResetDescriptorPool"));
+    vkAllocateDescriptorSets = (PFN_vkAllocateDescriptorSets)(vkGetInstanceProcAddr(instance, "vkAllocateDescriptorSets"));
+    vkFreeDescriptorSets = (PFN_vkFreeDescriptorSets)(vkGetInstanceProcAddr(instance, "vkFreeDescriptorSets"));
+    vkUpdateDescriptorSets = (PFN_vkUpdateDescriptorSets)(vkGetInstanceProcAddr(instance, "vkUpdateDescriptorSets"));
+    vkCreateFramebuffer = (PFN_vkCreateFramebuffer)(vkGetInstanceProcAddr(instance, "vkCreateFramebuffer"));
+    vkDestroyFramebuffer = (PFN_vkDestroyFramebuffer)(vkGetInstanceProcAddr(instance, "vkDestroyFramebuffer"));
+    vkCreateRenderPass = (PFN_vkCreateRenderPass)(vkGetInstanceProcAddr(instance, "vkCreateRenderPass"));
+    vkDestroyRenderPass = (PFN_vkDestroyRenderPass)(vkGetInstanceProcAddr(instance, "vkDestroyRenderPass"));
+    vkGetRenderAreaGranularity = (PFN_vkGetRenderAreaGranularity)(vkGetInstanceProcAddr(instance, "vkGetRenderAreaGranularity"));
+    vkCreateCommandPool = (PFN_vkCreateCommandPool)(vkGetInstanceProcAddr(instance, "vkCreateCommandPool"));
+    vkDestroyCommandPool = (PFN_vkDestroyCommandPool)(vkGetInstanceProcAddr(instance, "vkDestroyCommandPool"));
+    vkResetCommandPool = (PFN_vkResetCommandPool)(vkGetInstanceProcAddr(instance, "vkResetCommandPool"));
+    vkAllocateCommandBuffers = (PFN_vkAllocateCommandBuffers)(vkGetInstanceProcAddr(instance, "vkAllocateCommandBuffers"));
+    vkFreeCommandBuffers = (PFN_vkFreeCommandBuffers)(vkGetInstanceProcAddr(instance, "vkFreeCommandBuffers"));
+    vkBeginCommandBuffer = (PFN_vkBeginCommandBuffer)(vkGetInstanceProcAddr(instance, "vkBeginCommandBuffer"));
+    vkEndCommandBuffer = (PFN_vkEndCommandBuffer)(vkGetInstanceProcAddr(instance, "vkEndCommandBuffer"));
+    vkResetCommandBuffer = (PFN_vkResetCommandBuffer)(vkGetInstanceProcAddr(instance, "vkResetCommandBuffer"));
+    vkCmdBindPipeline = (PFN_vkCmdBindPipeline)(vkGetInstanceProcAddr(instance, "vkCmdBindPipeline"));
+    vkCmdSetViewport = (PFN_vkCmdSetViewport)(vkGetInstanceProcAddr(instance, "vkCmdSetViewport"));
+    vkCmdSetScissor = (PFN_vkCmdSetScissor)(vkGetInstanceProcAddr(instance, "vkCmdSetScissor"));
+    vkCmdSetLineWidth = (PFN_vkCmdSetLineWidth)(vkGetInstanceProcAddr(instance, "vkCmdSetLineWidth"));
+    vkCmdSetDepthBias = (PFN_vkCmdSetDepthBias)(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBias"));
+    vkCmdSetBlendConstants = (PFN_vkCmdSetBlendConstants)(vkGetInstanceProcAddr(instance, "vkCmdSetBlendConstants"));
+    vkCmdSetDepthBounds = (PFN_vkCmdSetDepthBounds)(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBounds"));
+    vkCmdSetStencilCompareMask = (PFN_vkCmdSetStencilCompareMask)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilCompareMask"));
+    vkCmdSetStencilWriteMask = (PFN_vkCmdSetStencilWriteMask)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilWriteMask"));
+    vkCmdSetStencilReference = (PFN_vkCmdSetStencilReference)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilReference"));
+    vkCmdBindDescriptorSets = (PFN_vkCmdBindDescriptorSets)(vkGetInstanceProcAddr(instance, "vkCmdBindDescriptorSets"));
+    vkCmdBindIndexBuffer = (PFN_vkCmdBindIndexBuffer)(vkGetInstanceProcAddr(instance, "vkCmdBindIndexBuffer"));
+    vkCmdBindVertexBuffers = (PFN_vkCmdBindVertexBuffers)(vkGetInstanceProcAddr(instance, "vkCmdBindVertexBuffers"));
+    vkCmdDraw = (PFN_vkCmdDraw)(vkGetInstanceProcAddr(instance, "vkCmdDraw"));
+    vkCmdDrawIndexed = (PFN_vkCmdDrawIndexed)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexed"));
+    vkCmdDrawIndirect = (PFN_vkCmdDrawIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndirect"));
+    vkCmdDrawIndexedIndirect = (PFN_vkCmdDrawIndexedIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexedIndirect"));
+    vkCmdDispatch = (PFN_vkCmdDispatch)(vkGetInstanceProcAddr(instance, "vkCmdDispatch"));
+    vkCmdDispatchIndirect = (PFN_vkCmdDispatchIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDispatchIndirect"));
+    vkCmdCopyBuffer = (PFN_vkCmdCopyBuffer)(vkGetInstanceProcAddr(instance, "vkCmdCopyBuffer"));
+    vkCmdCopyImage = (PFN_vkCmdCopyImage)(vkGetInstanceProcAddr(instance, "vkCmdCopyImage"));
+    vkCmdBlitImage = (PFN_vkCmdBlitImage)(vkGetInstanceProcAddr(instance, "vkCmdBlitImage"));
+    vkCmdCopyBufferToImage = (PFN_vkCmdCopyBufferToImage)(vkGetInstanceProcAddr(instance, "vkCmdCopyBufferToImage"));
+    vkCmdCopyImageToBuffer = (PFN_vkCmdCopyImageToBuffer)(vkGetInstanceProcAddr(instance, "vkCmdCopyImageToBuffer"));
+    vkCmdUpdateBuffer = (PFN_vkCmdUpdateBuffer)(vkGetInstanceProcAddr(instance, "vkCmdUpdateBuffer"));
+    vkCmdFillBuffer = (PFN_vkCmdFillBuffer)(vkGetInstanceProcAddr(instance, "vkCmdFillBuffer"));
+    vkCmdClearColorImage = (PFN_vkCmdClearColorImage)(vkGetInstanceProcAddr(instance, "vkCmdClearColorImage"));
+    vkCmdClearDepthStencilImage = (PFN_vkCmdClearDepthStencilImage)(vkGetInstanceProcAddr(instance, "vkCmdClearDepthStencilImage"));
+    vkCmdClearAttachments = (PFN_vkCmdClearAttachments)(vkGetInstanceProcAddr(instance, "vkCmdClearAttachments"));
+    vkCmdResolveImage = (PFN_vkCmdResolveImage)(vkGetInstanceProcAddr(instance, "vkCmdResolveImage"));
+    vkCmdSetEvent = (PFN_vkCmdSetEvent)(vkGetInstanceProcAddr(instance, "vkCmdSetEvent"));
+    vkCmdResetEvent = (PFN_vkCmdResetEvent)(vkGetInstanceProcAddr(instance, "vkCmdResetEvent"));
+    vkCmdWaitEvents = (PFN_vkCmdWaitEvents)(vkGetInstanceProcAddr(instance, "vkCmdWaitEvents"));
+    vkCmdPipelineBarrier = (PFN_vkCmdPipelineBarrier)(vkGetInstanceProcAddr(instance, "vkCmdPipelineBarrier"));
+    vkCmdBeginQuery = (PFN_vkCmdBeginQuery)(vkGetInstanceProcAddr(instance, "vkCmdBeginQuery"));
+    vkCmdEndQuery = (PFN_vkCmdEndQuery)(vkGetInstanceProcAddr(instance, "vkCmdEndQuery"));
+    vkCmdResetQueryPool = (PFN_vkCmdResetQueryPool)(vkGetInstanceProcAddr(instance, "vkCmdResetQueryPool"));
+    vkCmdWriteTimestamp = (PFN_vkCmdWriteTimestamp)(vkGetInstanceProcAddr(instance, "vkCmdWriteTimestamp"));
+    vkCmdCopyQueryPoolResults = (PFN_vkCmdCopyQueryPoolResults)(vkGetInstanceProcAddr(instance, "vkCmdCopyQueryPoolResults"));
+    vkCmdPushConstants = (PFN_vkCmdPushConstants)(vkGetInstanceProcAddr(instance, "vkCmdPushConstants"));
+    vkCmdBeginRenderPass = (PFN_vkCmdBeginRenderPass)(vkGetInstanceProcAddr(instance, "vkCmdBeginRenderPass"));
+    vkCmdNextSubpass = (PFN_vkCmdNextSubpass)(vkGetInstanceProcAddr(instance, "vkCmdNextSubpass"));
+    vkCmdEndRenderPass = (PFN_vkCmdEndRenderPass)(vkGetInstanceProcAddr(instance, "vkCmdEndRenderPass"));
+    vkCmdExecuteCommands = (PFN_vkCmdExecuteCommands)(vkGetInstanceProcAddr(instance, "vkCmdExecuteCommands"));
+    vkDestroySurfaceKHR = (PFN_vkDestroySurfaceKHR)(vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+    vkGetPhysicalDeviceSurfaceSupportKHR = (PFN_vkGetPhysicalDeviceSurfaceSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceSupportKHR"));
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
+    vkGetPhysicalDeviceSurfaceFormatsKHR = (PFN_vkGetPhysicalDeviceSurfaceFormatsKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceFormatsKHR"));
+    vkGetPhysicalDeviceSurfacePresentModesKHR = (PFN_vkGetPhysicalDeviceSurfacePresentModesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModesKHR"));
+    vkCreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)(vkGetInstanceProcAddr(instance, "vkCreateSwapchainKHR"));
+    vkDestroySwapchainKHR = (PFN_vkDestroySwapchainKHR)(vkGetInstanceProcAddr(instance, "vkDestroySwapchainKHR"));
+    vkGetSwapchainImagesKHR = (PFN_vkGetSwapchainImagesKHR)(vkGetInstanceProcAddr(instance, "vkGetSwapchainImagesKHR"));
+    vkAcquireNextImageKHR = (PFN_vkAcquireNextImageKHR)(vkGetInstanceProcAddr(instance, "vkAcquireNextImageKHR"));
+    vkQueuePresentKHR = (PFN_vkQueuePresentKHR)(vkGetInstanceProcAddr(instance, "vkQueuePresentKHR"));
+    vkGetPhysicalDeviceDisplayPropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPropertiesKHR"));
+    vkGetPhysicalDeviceDisplayPlanePropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
+    vkGetDisplayPlaneSupportedDisplaysKHR = (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayPlaneSupportedDisplaysKHR"));
+    vkGetDisplayModePropertiesKHR = (PFN_vkGetDisplayModePropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayModePropertiesKHR"));
+    vkCreateDisplayModeKHR = (PFN_vkCreateDisplayModeKHR)(vkGetInstanceProcAddr(instance, "vkCreateDisplayModeKHR"));
+    vkGetDisplayPlaneCapabilitiesKHR = (PFN_vkGetDisplayPlaneCapabilitiesKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayPlaneCapabilitiesKHR"));
+    vkCreateDisplayPlaneSurfaceKHR = (PFN_vkCreateDisplayPlaneSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateDisplayPlaneSurfaceKHR"));
+    vkCreateSharedSwapchainsKHR = (PFN_vkCreateSharedSwapchainsKHR)(vkGetInstanceProcAddr(instance, "vkCreateSharedSwapchainsKHR"));
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-    vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(dlsym(libvulkan, "vkCreateXlibSurfaceKHR"));
-    vkGetPhysicalDeviceXlibPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
+    vkCreateXlibSurfaceKHR = (PFN_vkCreateXlibSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR"));
+    vkGetPhysicalDeviceXlibPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-    vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(dlsym(libvulkan, "vkCreateXcbSurfaceKHR"));
-    vkGetPhysicalDeviceXcbPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
+    vkCreateXcbSurfaceKHR = (PFN_vkCreateXcbSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR"));
+    vkGetPhysicalDeviceXcbPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-    vkCreateWaylandSurfaceKHR = reinterpret_cast<PFN_vkCreateWaylandSurfaceKHR>(dlsym(libvulkan, "vkCreateWaylandSurfaceKHR"));
-    vkGetPhysicalDeviceWaylandPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
+    vkCreateWaylandSurfaceKHR = (PFN_vkCreateWaylandSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR"));
+    vkGetPhysicalDeviceWaylandPresentationSupportKHR = (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_MIR_KHR
-    vkCreateMirSurfaceKHR = reinterpret_cast<PFN_vkCreateMirSurfaceKHR>(dlsym(libvulkan, "vkCreateMirSurfaceKHR"));
-    vkGetPhysicalDeviceMirPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceMirPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceMirPresentationSupportKHR"));
+    vkCreateMirSurfaceKHR = (PFN_vkCreateMirSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateMirSurfaceKHR"));
+    vkGetPhysicalDeviceMirPresentationSupportKHR = (PFN_vkGetPhysicalDeviceMirPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMirPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    vkCreateAndroidSurfaceKHR = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(dlsym(libvulkan, "vkCreateAndroidSurfaceKHR"));
+    vkCreateAndroidSurfaceKHR = (PFN_vkCreateAndroidSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    vkCreateWin32SurfaceKHR = reinterpret_cast<PFN_vkCreateWin32SurfaceKHR>(dlsym(libvulkan, "vkCreateWin32SurfaceKHR"));
-    vkGetPhysicalDeviceWin32PresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
+    vkCreateWin32SurfaceKHR = (PFN_vkCreateWin32SurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR"));
+    vkGetPhysicalDeviceWin32PresentationSupportKHR = (PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
 #endif
 #ifdef USE_DEBUG_EXTENTIONS
-    vkCreateDebugReportCallbackEXT = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(dlsym(libvulkan, "vkCreateDebugReportCallbackEXT"));
-    vkDestroyDebugReportCallbackEXT = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(dlsym(libvulkan, "vkDestroyDebugReportCallbackEXT"));
-    vkDebugReportMessageEXT = reinterpret_cast<PFN_vkDebugReportMessageEXT>(dlsym(libvulkan, "vkDebugReportMessageEXT"));
+    vkCreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)(vkGetInstanceProcAddr(instance, "vkCreateDebugReportCallbackEXT"));
+    vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)(vkGetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT"));
+    vkDebugReportMessageEXT = (PFN_vkDebugReportMessageEXT)(vkGetInstanceProcAddr(instance, "vkDebugReportMessageEXT"));
 #endif
-    return 1;
+ return 1;
 }
 
 // No Vulkan support, do not set function addresses
+// Is it really necessary ?
 PFN_vkCreateInstance vkCreateInstance;
 PFN_vkDestroyInstance vkDestroyInstance;
 PFN_vkEnumeratePhysicalDevices vkEnumeratePhysicalDevices;
@@ -225,7 +298,7 @@ PFN_vkGetPhysicalDeviceQueueFamilyProperties vkGetPhysicalDeviceQueueFamilyPrope
 PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties;
 PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
 PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
-PFN_vkCreateDevice vkCreateDevice;
+
 PFN_vkDestroyDevice vkDestroyDevice;
 PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties;
 PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;

--- a/common/vulkan_wrapper/vulkan_wrapper.h
+++ b/common/vulkan_wrapper/vulkan_wrapper.h
@@ -19,13 +19,13 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 
-/** 
+/**
  * Initialize Vulkan function pointer variables declared in this header.
  * After call, following functions will be available:
  *  vkEnumerateInstanceExtensionProperties
  *  vkEnumerateInstanceLayerProperties
  *  vkCreateInstance
- *  
+ *
  * Note: core functions will be available after vkCreateInstance() call.
  *
  * @returns 0 if vulkan is not available, non-zero otherwise.

--- a/common/vulkan_wrapper/vulkan_wrapper.h
+++ b/common/vulkan_wrapper/vulkan_wrapper.h
@@ -19,10 +19,37 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 
-/* Initialize the Vulkan function pointer variables declared in this header.
- * Returns 0 if vulkan is not available, non-zero if it is available.
+// enable all extensions
+#ifndef VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT
+ #define VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT 1
+#endif
+
+
+/** 
+ * Initialize Vulkan function pointer variables declared in this header.
+ * After call, following functions will be available:
+ *  vkEnumerateInstanceExtensionProperties
+ *  vkEnumerateInstanceLayerProperties
+ *  vkCreateInstance
+ *  
+ * Note: core functions will be available after vkCreateInstance() call.
+ *
+ * @returns 0 if vulkan is not available, non-zero otherwise.
  */
-int InitVulkan(void);
+extern int InitVulkan(void);
+
+// flag
+extern bool isInstanceLoaded = false;
+
+// Available extensions and layers
+extern char* ppAvailableExtensions[];
+extern char* ppAvailableLayers[]; 
+
+extern uint32_t availableExtensionsCount;
+extern uint32_t availableLayersCount; 
+
+//hook
+PFN_vkCreateInstance vkCreateInstance_HOOK;
 
 // VK_core
 extern PFN_vkCreateInstance vkCreateInstance;

--- a/common/vulkan_wrapper/vulkan_wrapper.h
+++ b/common/vulkan_wrapper/vulkan_wrapper.h
@@ -38,18 +38,6 @@
  */
 extern int InitVulkan(void);
 
-// flag
-extern bool isInstanceLoaded = false;
-
-// Available extensions and layers
-extern char* ppAvailableExtensions[];
-extern char* ppAvailableLayers[]; 
-
-extern uint32_t availableExtensionsCount;
-extern uint32_t availableLayersCount; 
-
-//hook
-PFN_vkCreateInstance vkCreateInstance_HOOK;
 
 // VK_core
 extern PFN_vkCreateInstance vkCreateInstance;

--- a/common/vulkan_wrapper/vulkan_wrapper.h
+++ b/common/vulkan_wrapper/vulkan_wrapper.h
@@ -19,12 +19,6 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 
-// enable all extensions
-#ifndef VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT
- #define VULKAN_WRAPPER_ENABLE_ALL_EXTENSIONS_DEFAULT 1
-#endif
-
-
 /** 
  * Initialize Vulkan function pointer variables declared in this header.
  * After call, following functions will be available:

--- a/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
+++ b/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
@@ -11,12 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 // This file is handmade.
-
-#include <string.h>
-#include <vector>
-#include <stdio.h>
 
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
@@ -64,7 +59,8 @@ int InitVulkan(void) {
     // Set an hook to real vkCreateInstance
     vkCreateInstance_HOOK = (PFN_vkCreateInstance) (vkGetInstanceProcAddr(nullptr, "vkCreateInstance"));
     // point public vkCreateInstance to our delegate function
-    vkCreateInstance = &vkCreateInstanceDelegate;    
+    vkCreateInstance = &vkCreateInstanceDelegate;   
+    return 1;
 }
 
 /**

--- a/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
+++ b/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
@@ -11,207 +11,290 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// This file is generated.
-#include "vulkan_wrapper.h"
-#include <dlfcn.h>
 
+// This file is handmade.
+
+#include <string.h>
+#include <vector>
+#include <stdio.h>
+
+#define VK_NO_PROTOTYPES 1
+#include <vulkan/vulkan.h>
+#include "vulkan_wrapper.h"
+
+#ifdef _WIN32
+   #include <windows.h>
+   #include <wchar.h>
+#else
+   #include <dlfcn.h>
+#endif
+
+// a hook to Vulkan native function
+static PFN_vkCreateInstance vkCreateInstance_HOOK;
+
+/**
+ * Forward declaration  
+ */
+VkResult vkCreateInstanceDelegate( const VkInstanceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator,
+			           VkInstance* pInstance);
+
+/**
+ * Forward declaration.
+ * This is the procedure to load all remaining Vulkan functions.
+ * @return 0 if failed to load functions, non-zero otherwise
+ */
+int LoadInstanceProcs(VkInstance instance);
+
+/**
+ * Initialize Vulkan loading
+ * @return 0 if failed to init Vulkan
+ */
 int InitVulkan(void) {
-    void* libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+#ifdef _WIN32
+    #define LoadProcAddress GetProcAddress
+    HINSTANCE  libvulkan = NULL;    
+    libvulkan = LoadLibrary("vulkan-1.dll");   
+#else  // all *nix
+    #define LoadProcAddress dlsym
+    void* libvulkan = nullptr;    
+    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	
+#endif    
+    
     if (!libvulkan)
         return 0;
+    // the only one function to be loaded using dlsym	
+    vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(LoadProcAddress(libvulkan, "vkGetInstanceProcAddr"));	
+	
+    if(!vkGetInstanceProcAddr)
+	   return 0;
 
-    // Vulkan supported, set function addresses
-    vkCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(dlsym(libvulkan, "vkCreateInstance"));
-    vkDestroyInstance = reinterpret_cast<PFN_vkDestroyInstance>(dlsym(libvulkan, "vkDestroyInstance"));
-    vkEnumeratePhysicalDevices = reinterpret_cast<PFN_vkEnumeratePhysicalDevices>(dlsym(libvulkan, "vkEnumeratePhysicalDevices"));
-    vkGetPhysicalDeviceFeatures = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures>(dlsym(libvulkan, "vkGetPhysicalDeviceFeatures"));
-    vkGetPhysicalDeviceFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceFormatProperties"));
-    vkGetPhysicalDeviceImageFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceImageFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceImageFormatProperties"));
-    vkGetPhysicalDeviceProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceProperties"));
-    vkGetPhysicalDeviceQueueFamilyProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceQueueFamilyProperties"));
-    vkGetPhysicalDeviceMemoryProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceMemoryProperties"));
-    vkGetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libvulkan, "vkGetInstanceProcAddr"));
-    vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(dlsym(libvulkan, "vkGetDeviceProcAddr"));
-    vkCreateDevice = reinterpret_cast<PFN_vkCreateDevice>(dlsym(libvulkan, "vkCreateDevice"));
-    vkDestroyDevice = reinterpret_cast<PFN_vkDestroyDevice>(dlsym(libvulkan, "vkDestroyDevice"));
-    vkEnumerateInstanceExtensionProperties = reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(dlsym(libvulkan, "vkEnumerateInstanceExtensionProperties"));
-    vkEnumerateDeviceExtensionProperties = reinterpret_cast<PFN_vkEnumerateDeviceExtensionProperties>(dlsym(libvulkan, "vkEnumerateDeviceExtensionProperties"));
-    vkEnumerateInstanceLayerProperties = reinterpret_cast<PFN_vkEnumerateInstanceLayerProperties>(dlsym(libvulkan, "vkEnumerateInstanceLayerProperties"));
-    vkEnumerateDeviceLayerProperties = reinterpret_cast<PFN_vkEnumerateDeviceLayerProperties>(dlsym(libvulkan, "vkEnumerateDeviceLayerProperties"));
-    vkGetDeviceQueue = reinterpret_cast<PFN_vkGetDeviceQueue>(dlsym(libvulkan, "vkGetDeviceQueue"));
-    vkQueueSubmit = reinterpret_cast<PFN_vkQueueSubmit>(dlsym(libvulkan, "vkQueueSubmit"));
-    vkQueueWaitIdle = reinterpret_cast<PFN_vkQueueWaitIdle>(dlsym(libvulkan, "vkQueueWaitIdle"));
-    vkDeviceWaitIdle = reinterpret_cast<PFN_vkDeviceWaitIdle>(dlsym(libvulkan, "vkDeviceWaitIdle"));
-    vkAllocateMemory = reinterpret_cast<PFN_vkAllocateMemory>(dlsym(libvulkan, "vkAllocateMemory"));
-    vkFreeMemory = reinterpret_cast<PFN_vkFreeMemory>(dlsym(libvulkan, "vkFreeMemory"));
-    vkMapMemory = reinterpret_cast<PFN_vkMapMemory>(dlsym(libvulkan, "vkMapMemory"));
-    vkUnmapMemory = reinterpret_cast<PFN_vkUnmapMemory>(dlsym(libvulkan, "vkUnmapMemory"));
-    vkFlushMappedMemoryRanges = reinterpret_cast<PFN_vkFlushMappedMemoryRanges>(dlsym(libvulkan, "vkFlushMappedMemoryRanges"));
-    vkInvalidateMappedMemoryRanges = reinterpret_cast<PFN_vkInvalidateMappedMemoryRanges>(dlsym(libvulkan, "vkInvalidateMappedMemoryRanges"));
-    vkGetDeviceMemoryCommitment = reinterpret_cast<PFN_vkGetDeviceMemoryCommitment>(dlsym(libvulkan, "vkGetDeviceMemoryCommitment"));
-    vkBindBufferMemory = reinterpret_cast<PFN_vkBindBufferMemory>(dlsym(libvulkan, "vkBindBufferMemory"));
-    vkBindImageMemory = reinterpret_cast<PFN_vkBindImageMemory>(dlsym(libvulkan, "vkBindImageMemory"));
-    vkGetBufferMemoryRequirements = reinterpret_cast<PFN_vkGetBufferMemoryRequirements>(dlsym(libvulkan, "vkGetBufferMemoryRequirements"));
-    vkGetImageMemoryRequirements = reinterpret_cast<PFN_vkGetImageMemoryRequirements>(dlsym(libvulkan, "vkGetImageMemoryRequirements"));
-    vkGetImageSparseMemoryRequirements = reinterpret_cast<PFN_vkGetImageSparseMemoryRequirements>(dlsym(libvulkan, "vkGetImageSparseMemoryRequirements"));
-    vkGetPhysicalDeviceSparseImageFormatProperties = reinterpret_cast<PFN_vkGetPhysicalDeviceSparseImageFormatProperties>(dlsym(libvulkan, "vkGetPhysicalDeviceSparseImageFormatProperties"));
-    vkQueueBindSparse = reinterpret_cast<PFN_vkQueueBindSparse>(dlsym(libvulkan, "vkQueueBindSparse"));
-    vkCreateFence = reinterpret_cast<PFN_vkCreateFence>(dlsym(libvulkan, "vkCreateFence"));
-    vkDestroyFence = reinterpret_cast<PFN_vkDestroyFence>(dlsym(libvulkan, "vkDestroyFence"));
-    vkResetFences = reinterpret_cast<PFN_vkResetFences>(dlsym(libvulkan, "vkResetFences"));
-    vkGetFenceStatus = reinterpret_cast<PFN_vkGetFenceStatus>(dlsym(libvulkan, "vkGetFenceStatus"));
-    vkWaitForFences = reinterpret_cast<PFN_vkWaitForFences>(dlsym(libvulkan, "vkWaitForFences"));
-    vkCreateSemaphore = reinterpret_cast<PFN_vkCreateSemaphore>(dlsym(libvulkan, "vkCreateSemaphore"));
-    vkDestroySemaphore = reinterpret_cast<PFN_vkDestroySemaphore>(dlsym(libvulkan, "vkDestroySemaphore"));
-    vkCreateEvent = reinterpret_cast<PFN_vkCreateEvent>(dlsym(libvulkan, "vkCreateEvent"));
-    vkDestroyEvent = reinterpret_cast<PFN_vkDestroyEvent>(dlsym(libvulkan, "vkDestroyEvent"));
-    vkGetEventStatus = reinterpret_cast<PFN_vkGetEventStatus>(dlsym(libvulkan, "vkGetEventStatus"));
-    vkSetEvent = reinterpret_cast<PFN_vkSetEvent>(dlsym(libvulkan, "vkSetEvent"));
-    vkResetEvent = reinterpret_cast<PFN_vkResetEvent>(dlsym(libvulkan, "vkResetEvent"));
-    vkCreateQueryPool = reinterpret_cast<PFN_vkCreateQueryPool>(dlsym(libvulkan, "vkCreateQueryPool"));
-    vkDestroyQueryPool = reinterpret_cast<PFN_vkDestroyQueryPool>(dlsym(libvulkan, "vkDestroyQueryPool"));
-    vkGetQueryPoolResults = reinterpret_cast<PFN_vkGetQueryPoolResults>(dlsym(libvulkan, "vkGetQueryPoolResults"));
-    vkCreateBuffer = reinterpret_cast<PFN_vkCreateBuffer>(dlsym(libvulkan, "vkCreateBuffer"));
-    vkDestroyBuffer = reinterpret_cast<PFN_vkDestroyBuffer>(dlsym(libvulkan, "vkDestroyBuffer"));
-    vkCreateBufferView = reinterpret_cast<PFN_vkCreateBufferView>(dlsym(libvulkan, "vkCreateBufferView"));
-    vkDestroyBufferView = reinterpret_cast<PFN_vkDestroyBufferView>(dlsym(libvulkan, "vkDestroyBufferView"));
-    vkCreateImage = reinterpret_cast<PFN_vkCreateImage>(dlsym(libvulkan, "vkCreateImage"));
-    vkDestroyImage = reinterpret_cast<PFN_vkDestroyImage>(dlsym(libvulkan, "vkDestroyImage"));
-    vkGetImageSubresourceLayout = reinterpret_cast<PFN_vkGetImageSubresourceLayout>(dlsym(libvulkan, "vkGetImageSubresourceLayout"));
-    vkCreateImageView = reinterpret_cast<PFN_vkCreateImageView>(dlsym(libvulkan, "vkCreateImageView"));
-    vkDestroyImageView = reinterpret_cast<PFN_vkDestroyImageView>(dlsym(libvulkan, "vkDestroyImageView"));
-    vkCreateShaderModule = reinterpret_cast<PFN_vkCreateShaderModule>(dlsym(libvulkan, "vkCreateShaderModule"));
-    vkDestroyShaderModule = reinterpret_cast<PFN_vkDestroyShaderModule>(dlsym(libvulkan, "vkDestroyShaderModule"));
-    vkCreatePipelineCache = reinterpret_cast<PFN_vkCreatePipelineCache>(dlsym(libvulkan, "vkCreatePipelineCache"));
-    vkDestroyPipelineCache = reinterpret_cast<PFN_vkDestroyPipelineCache>(dlsym(libvulkan, "vkDestroyPipelineCache"));
-    vkGetPipelineCacheData = reinterpret_cast<PFN_vkGetPipelineCacheData>(dlsym(libvulkan, "vkGetPipelineCacheData"));
-    vkMergePipelineCaches = reinterpret_cast<PFN_vkMergePipelineCaches>(dlsym(libvulkan, "vkMergePipelineCaches"));
-    vkCreateGraphicsPipelines = reinterpret_cast<PFN_vkCreateGraphicsPipelines>(dlsym(libvulkan, "vkCreateGraphicsPipelines"));
-    vkCreateComputePipelines = reinterpret_cast<PFN_vkCreateComputePipelines>(dlsym(libvulkan, "vkCreateComputePipelines"));
-    vkDestroyPipeline = reinterpret_cast<PFN_vkDestroyPipeline>(dlsym(libvulkan, "vkDestroyPipeline"));
-    vkCreatePipelineLayout = reinterpret_cast<PFN_vkCreatePipelineLayout>(dlsym(libvulkan, "vkCreatePipelineLayout"));
-    vkDestroyPipelineLayout = reinterpret_cast<PFN_vkDestroyPipelineLayout>(dlsym(libvulkan, "vkDestroyPipelineLayout"));
-    vkCreateSampler = reinterpret_cast<PFN_vkCreateSampler>(dlsym(libvulkan, "vkCreateSampler"));
-    vkDestroySampler = reinterpret_cast<PFN_vkDestroySampler>(dlsym(libvulkan, "vkDestroySampler"));
-    vkCreateDescriptorSetLayout = reinterpret_cast<PFN_vkCreateDescriptorSetLayout>(dlsym(libvulkan, "vkCreateDescriptorSetLayout"));
-    vkDestroyDescriptorSetLayout = reinterpret_cast<PFN_vkDestroyDescriptorSetLayout>(dlsym(libvulkan, "vkDestroyDescriptorSetLayout"));
-    vkCreateDescriptorPool = reinterpret_cast<PFN_vkCreateDescriptorPool>(dlsym(libvulkan, "vkCreateDescriptorPool"));
-    vkDestroyDescriptorPool = reinterpret_cast<PFN_vkDestroyDescriptorPool>(dlsym(libvulkan, "vkDestroyDescriptorPool"));
-    vkResetDescriptorPool = reinterpret_cast<PFN_vkResetDescriptorPool>(dlsym(libvulkan, "vkResetDescriptorPool"));
-    vkAllocateDescriptorSets = reinterpret_cast<PFN_vkAllocateDescriptorSets>(dlsym(libvulkan, "vkAllocateDescriptorSets"));
-    vkFreeDescriptorSets = reinterpret_cast<PFN_vkFreeDescriptorSets>(dlsym(libvulkan, "vkFreeDescriptorSets"));
-    vkUpdateDescriptorSets = reinterpret_cast<PFN_vkUpdateDescriptorSets>(dlsym(libvulkan, "vkUpdateDescriptorSets"));
-    vkCreateFramebuffer = reinterpret_cast<PFN_vkCreateFramebuffer>(dlsym(libvulkan, "vkCreateFramebuffer"));
-    vkDestroyFramebuffer = reinterpret_cast<PFN_vkDestroyFramebuffer>(dlsym(libvulkan, "vkDestroyFramebuffer"));
-    vkCreateRenderPass = reinterpret_cast<PFN_vkCreateRenderPass>(dlsym(libvulkan, "vkCreateRenderPass"));
-    vkDestroyRenderPass = reinterpret_cast<PFN_vkDestroyRenderPass>(dlsym(libvulkan, "vkDestroyRenderPass"));
-    vkGetRenderAreaGranularity = reinterpret_cast<PFN_vkGetRenderAreaGranularity>(dlsym(libvulkan, "vkGetRenderAreaGranularity"));
-    vkCreateCommandPool = reinterpret_cast<PFN_vkCreateCommandPool>(dlsym(libvulkan, "vkCreateCommandPool"));
-    vkDestroyCommandPool = reinterpret_cast<PFN_vkDestroyCommandPool>(dlsym(libvulkan, "vkDestroyCommandPool"));
-    vkResetCommandPool = reinterpret_cast<PFN_vkResetCommandPool>(dlsym(libvulkan, "vkResetCommandPool"));
-    vkAllocateCommandBuffers = reinterpret_cast<PFN_vkAllocateCommandBuffers>(dlsym(libvulkan, "vkAllocateCommandBuffers"));
-    vkFreeCommandBuffers = reinterpret_cast<PFN_vkFreeCommandBuffers>(dlsym(libvulkan, "vkFreeCommandBuffers"));
-    vkBeginCommandBuffer = reinterpret_cast<PFN_vkBeginCommandBuffer>(dlsym(libvulkan, "vkBeginCommandBuffer"));
-    vkEndCommandBuffer = reinterpret_cast<PFN_vkEndCommandBuffer>(dlsym(libvulkan, "vkEndCommandBuffer"));
-    vkResetCommandBuffer = reinterpret_cast<PFN_vkResetCommandBuffer>(dlsym(libvulkan, "vkResetCommandBuffer"));
-    vkCmdBindPipeline = reinterpret_cast<PFN_vkCmdBindPipeline>(dlsym(libvulkan, "vkCmdBindPipeline"));
-    vkCmdSetViewport = reinterpret_cast<PFN_vkCmdSetViewport>(dlsym(libvulkan, "vkCmdSetViewport"));
-    vkCmdSetScissor = reinterpret_cast<PFN_vkCmdSetScissor>(dlsym(libvulkan, "vkCmdSetScissor"));
-    vkCmdSetLineWidth = reinterpret_cast<PFN_vkCmdSetLineWidth>(dlsym(libvulkan, "vkCmdSetLineWidth"));
-    vkCmdSetDepthBias = reinterpret_cast<PFN_vkCmdSetDepthBias>(dlsym(libvulkan, "vkCmdSetDepthBias"));
-    vkCmdSetBlendConstants = reinterpret_cast<PFN_vkCmdSetBlendConstants>(dlsym(libvulkan, "vkCmdSetBlendConstants"));
-    vkCmdSetDepthBounds = reinterpret_cast<PFN_vkCmdSetDepthBounds>(dlsym(libvulkan, "vkCmdSetDepthBounds"));
-    vkCmdSetStencilCompareMask = reinterpret_cast<PFN_vkCmdSetStencilCompareMask>(dlsym(libvulkan, "vkCmdSetStencilCompareMask"));
-    vkCmdSetStencilWriteMask = reinterpret_cast<PFN_vkCmdSetStencilWriteMask>(dlsym(libvulkan, "vkCmdSetStencilWriteMask"));
-    vkCmdSetStencilReference = reinterpret_cast<PFN_vkCmdSetStencilReference>(dlsym(libvulkan, "vkCmdSetStencilReference"));
-    vkCmdBindDescriptorSets = reinterpret_cast<PFN_vkCmdBindDescriptorSets>(dlsym(libvulkan, "vkCmdBindDescriptorSets"));
-    vkCmdBindIndexBuffer = reinterpret_cast<PFN_vkCmdBindIndexBuffer>(dlsym(libvulkan, "vkCmdBindIndexBuffer"));
-    vkCmdBindVertexBuffers = reinterpret_cast<PFN_vkCmdBindVertexBuffers>(dlsym(libvulkan, "vkCmdBindVertexBuffers"));
-    vkCmdDraw = reinterpret_cast<PFN_vkCmdDraw>(dlsym(libvulkan, "vkCmdDraw"));
-    vkCmdDrawIndexed = reinterpret_cast<PFN_vkCmdDrawIndexed>(dlsym(libvulkan, "vkCmdDrawIndexed"));
-    vkCmdDrawIndirect = reinterpret_cast<PFN_vkCmdDrawIndirect>(dlsym(libvulkan, "vkCmdDrawIndirect"));
-    vkCmdDrawIndexedIndirect = reinterpret_cast<PFN_vkCmdDrawIndexedIndirect>(dlsym(libvulkan, "vkCmdDrawIndexedIndirect"));
-    vkCmdDispatch = reinterpret_cast<PFN_vkCmdDispatch>(dlsym(libvulkan, "vkCmdDispatch"));
-    vkCmdDispatchIndirect = reinterpret_cast<PFN_vkCmdDispatchIndirect>(dlsym(libvulkan, "vkCmdDispatchIndirect"));
-    vkCmdCopyBuffer = reinterpret_cast<PFN_vkCmdCopyBuffer>(dlsym(libvulkan, "vkCmdCopyBuffer"));
-    vkCmdCopyImage = reinterpret_cast<PFN_vkCmdCopyImage>(dlsym(libvulkan, "vkCmdCopyImage"));
-    vkCmdBlitImage = reinterpret_cast<PFN_vkCmdBlitImage>(dlsym(libvulkan, "vkCmdBlitImage"));
-    vkCmdCopyBufferToImage = reinterpret_cast<PFN_vkCmdCopyBufferToImage>(dlsym(libvulkan, "vkCmdCopyBufferToImage"));
-    vkCmdCopyImageToBuffer = reinterpret_cast<PFN_vkCmdCopyImageToBuffer>(dlsym(libvulkan, "vkCmdCopyImageToBuffer"));
-    vkCmdUpdateBuffer = reinterpret_cast<PFN_vkCmdUpdateBuffer>(dlsym(libvulkan, "vkCmdUpdateBuffer"));
-    vkCmdFillBuffer = reinterpret_cast<PFN_vkCmdFillBuffer>(dlsym(libvulkan, "vkCmdFillBuffer"));
-    vkCmdClearColorImage = reinterpret_cast<PFN_vkCmdClearColorImage>(dlsym(libvulkan, "vkCmdClearColorImage"));
-    vkCmdClearDepthStencilImage = reinterpret_cast<PFN_vkCmdClearDepthStencilImage>(dlsym(libvulkan, "vkCmdClearDepthStencilImage"));
-    vkCmdClearAttachments = reinterpret_cast<PFN_vkCmdClearAttachments>(dlsym(libvulkan, "vkCmdClearAttachments"));
-    vkCmdResolveImage = reinterpret_cast<PFN_vkCmdResolveImage>(dlsym(libvulkan, "vkCmdResolveImage"));
-    vkCmdSetEvent = reinterpret_cast<PFN_vkCmdSetEvent>(dlsym(libvulkan, "vkCmdSetEvent"));
-    vkCmdResetEvent = reinterpret_cast<PFN_vkCmdResetEvent>(dlsym(libvulkan, "vkCmdResetEvent"));
-    vkCmdWaitEvents = reinterpret_cast<PFN_vkCmdWaitEvents>(dlsym(libvulkan, "vkCmdWaitEvents"));
-    vkCmdPipelineBarrier = reinterpret_cast<PFN_vkCmdPipelineBarrier>(dlsym(libvulkan, "vkCmdPipelineBarrier"));
-    vkCmdBeginQuery = reinterpret_cast<PFN_vkCmdBeginQuery>(dlsym(libvulkan, "vkCmdBeginQuery"));
-    vkCmdEndQuery = reinterpret_cast<PFN_vkCmdEndQuery>(dlsym(libvulkan, "vkCmdEndQuery"));
-    vkCmdResetQueryPool = reinterpret_cast<PFN_vkCmdResetQueryPool>(dlsym(libvulkan, "vkCmdResetQueryPool"));
-    vkCmdWriteTimestamp = reinterpret_cast<PFN_vkCmdWriteTimestamp>(dlsym(libvulkan, "vkCmdWriteTimestamp"));
-    vkCmdCopyQueryPoolResults = reinterpret_cast<PFN_vkCmdCopyQueryPoolResults>(dlsym(libvulkan, "vkCmdCopyQueryPoolResults"));
-    vkCmdPushConstants = reinterpret_cast<PFN_vkCmdPushConstants>(dlsym(libvulkan, "vkCmdPushConstants"));
-    vkCmdBeginRenderPass = reinterpret_cast<PFN_vkCmdBeginRenderPass>(dlsym(libvulkan, "vkCmdBeginRenderPass"));
-    vkCmdNextSubpass = reinterpret_cast<PFN_vkCmdNextSubpass>(dlsym(libvulkan, "vkCmdNextSubpass"));
-    vkCmdEndRenderPass = reinterpret_cast<PFN_vkCmdEndRenderPass>(dlsym(libvulkan, "vkCmdEndRenderPass"));
-    vkCmdExecuteCommands = reinterpret_cast<PFN_vkCmdExecuteCommands>(dlsym(libvulkan, "vkCmdExecuteCommands"));
-    vkDestroySurfaceKHR = reinterpret_cast<PFN_vkDestroySurfaceKHR>(dlsym(libvulkan, "vkDestroySurfaceKHR"));
-    vkGetPhysicalDeviceSurfaceSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceSupportKHR"));
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
-    vkGetPhysicalDeviceSurfaceFormatsKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormatsKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfaceFormatsKHR"));
-    vkGetPhysicalDeviceSurfacePresentModesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceSurfacePresentModesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceSurfacePresentModesKHR"));
-    vkCreateSwapchainKHR = reinterpret_cast<PFN_vkCreateSwapchainKHR>(dlsym(libvulkan, "vkCreateSwapchainKHR"));
-    vkDestroySwapchainKHR = reinterpret_cast<PFN_vkDestroySwapchainKHR>(dlsym(libvulkan, "vkDestroySwapchainKHR"));
-    vkGetSwapchainImagesKHR = reinterpret_cast<PFN_vkGetSwapchainImagesKHR>(dlsym(libvulkan, "vkGetSwapchainImagesKHR"));
-    vkAcquireNextImageKHR = reinterpret_cast<PFN_vkAcquireNextImageKHR>(dlsym(libvulkan, "vkAcquireNextImageKHR"));
-    vkQueuePresentKHR = reinterpret_cast<PFN_vkQueuePresentKHR>(dlsym(libvulkan, "vkQueuePresentKHR"));
-    vkGetPhysicalDeviceDisplayPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPropertiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceDisplayPropertiesKHR"));
-    vkGetPhysicalDeviceDisplayPlanePropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
-    vkGetDisplayPlaneSupportedDisplaysKHR = reinterpret_cast<PFN_vkGetDisplayPlaneSupportedDisplaysKHR>(dlsym(libvulkan, "vkGetDisplayPlaneSupportedDisplaysKHR"));
-    vkGetDisplayModePropertiesKHR = reinterpret_cast<PFN_vkGetDisplayModePropertiesKHR>(dlsym(libvulkan, "vkGetDisplayModePropertiesKHR"));
-    vkCreateDisplayModeKHR = reinterpret_cast<PFN_vkCreateDisplayModeKHR>(dlsym(libvulkan, "vkCreateDisplayModeKHR"));
-    vkGetDisplayPlaneCapabilitiesKHR = reinterpret_cast<PFN_vkGetDisplayPlaneCapabilitiesKHR>(dlsym(libvulkan, "vkGetDisplayPlaneCapabilitiesKHR"));
-    vkCreateDisplayPlaneSurfaceKHR = reinterpret_cast<PFN_vkCreateDisplayPlaneSurfaceKHR>(dlsym(libvulkan, "vkCreateDisplayPlaneSurfaceKHR"));
-    vkCreateSharedSwapchainsKHR = reinterpret_cast<PFN_vkCreateSharedSwapchainsKHR>(dlsym(libvulkan, "vkCreateSharedSwapchainsKHR"));
+    //load the two basic functions required by VkCreateInstance
+    vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties) (vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceExtensionProperties"));
+    vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties) (vkGetInstanceProcAddr(nullptr, "vkEnumerateInstanceLayerProperties"));
+    // Set an hook to real vkCreateInstance
+    vkCreateInstance_HOOK = (PFN_vkCreateInstance) (vkGetInstanceProcAddr(nullptr, "vkCreateInstance"));
+    // point public vkCreateInstance to our delegate function
+    vkCreateInstance = &vkCreateInstanceDelegate;    
+}
+
+/**
+ * Delegate function to vkCreateInstance
+ * This functions intercepts vkCreateInstance calls and loads all Vulkan functions.
+ */
+VkResult vkCreateInstanceDelegate( const VkInstanceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator,
+			           VkInstance* pInstance){
+    VkResult res = vkCreateInstance_HOOK(pCreateInfo, pAllocator, pInstance);    
+    if(res < 0){
+	return res;
+    }	
+    //Load VkInstance's related functions
+    VkInstance instance = *pInstance;
+    LoadInstanceProcs(instance);    
+    return res;
+}
+
+
+/**
+ * This function loads all related VKInstance functions
+ * @param instance - non null VkInstance to load 
+ */
+int LoadInstanceProcs(VkInstance instance){
+    if(!instance)
+       return 0;
+
+    vkDestroyInstance = (PFN_vkDestroyInstance)(vkGetInstanceProcAddr(instance, "vkDestroyInstance"));
+    vkEnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)(vkGetInstanceProcAddr(instance, "vkEnumeratePhysicalDevices"));
+    vkGetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures"));
+    vkGetPhysicalDeviceFormatProperties = (PFN_vkGetPhysicalDeviceFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceFormatProperties"));
+    vkGetPhysicalDeviceImageFormatProperties = (PFN_vkGetPhysicalDeviceImageFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceImageFormatProperties"));
+    vkGetPhysicalDeviceProperties = (PFN_vkGetPhysicalDeviceProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties"));
+    vkGetPhysicalDeviceQueueFamilyProperties = (PFN_vkGetPhysicalDeviceQueueFamilyProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceQueueFamilyProperties"));
+    vkGetPhysicalDeviceMemoryProperties = (PFN_vkGetPhysicalDeviceMemoryProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMemoryProperties"));
+    vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(vkGetInstanceProcAddr(instance, "vkGetInstanceProcAddr"));
+    vkGetDeviceProcAddr = (PFN_vkGetDeviceProcAddr)(vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr"));
+    vkCreateDevice = (PFN_vkCreateDevice)(vkGetInstanceProcAddr(instance, "vkCreateDevice"));
+    vkDestroyDevice = (PFN_vkDestroyDevice)(vkGetInstanceProcAddr(instance, "vkDestroyDevice"));
+//  vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceExtensionProperties"));
+    vkEnumerateDeviceExtensionProperties = (PFN_vkEnumerateDeviceExtensionProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceExtensionProperties"));
+//  vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateInstanceLayerProperties"));
+    vkEnumerateDeviceLayerProperties = (PFN_vkEnumerateDeviceLayerProperties)(vkGetInstanceProcAddr(instance, "vkEnumerateDeviceLayerProperties"));
+    vkGetDeviceQueue = (PFN_vkGetDeviceQueue)(vkGetInstanceProcAddr(instance, "vkGetDeviceQueue"));
+    vkQueueSubmit = (PFN_vkQueueSubmit)(vkGetInstanceProcAddr(instance, "vkQueueSubmit"));
+    vkQueueWaitIdle = (PFN_vkQueueWaitIdle)(vkGetInstanceProcAddr(instance, "vkQueueWaitIdle"));
+    vkDeviceWaitIdle = (PFN_vkDeviceWaitIdle)(vkGetInstanceProcAddr(instance, "vkDeviceWaitIdle"));
+    vkAllocateMemory = (PFN_vkAllocateMemory)(vkGetInstanceProcAddr(instance, "vkAllocateMemory"));
+    vkFreeMemory = (PFN_vkFreeMemory)(vkGetInstanceProcAddr(instance, "vkFreeMemory"));
+    vkMapMemory = (PFN_vkMapMemory)(vkGetInstanceProcAddr(instance, "vkMapMemory"));
+    vkUnmapMemory = (PFN_vkUnmapMemory)(vkGetInstanceProcAddr(instance, "vkUnmapMemory"));
+    vkFlushMappedMemoryRanges = (PFN_vkFlushMappedMemoryRanges)(vkGetInstanceProcAddr(instance, "vkFlushMappedMemoryRanges"));
+    vkInvalidateMappedMemoryRanges = (PFN_vkInvalidateMappedMemoryRanges)(vkGetInstanceProcAddr(instance, "vkInvalidateMappedMemoryRanges"));
+    vkGetDeviceMemoryCommitment = (PFN_vkGetDeviceMemoryCommitment)(vkGetInstanceProcAddr(instance, "vkGetDeviceMemoryCommitment"));
+    vkBindBufferMemory = (PFN_vkBindBufferMemory)(vkGetInstanceProcAddr(instance, "vkBindBufferMemory"));
+    vkBindImageMemory = (PFN_vkBindImageMemory)(vkGetInstanceProcAddr(instance, "vkBindImageMemory"));
+    vkGetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetBufferMemoryRequirements"));
+    vkGetImageMemoryRequirements = (PFN_vkGetImageMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetImageMemoryRequirements"));
+    vkGetImageSparseMemoryRequirements = (PFN_vkGetImageSparseMemoryRequirements)(vkGetInstanceProcAddr(instance, "vkGetImageSparseMemoryRequirements"));
+    vkGetPhysicalDeviceSparseImageFormatProperties = (PFN_vkGetPhysicalDeviceSparseImageFormatProperties)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSparseImageFormatProperties"));
+    vkQueueBindSparse = (PFN_vkQueueBindSparse)(vkGetInstanceProcAddr(instance, "vkQueueBindSparse"));
+    vkCreateFence = (PFN_vkCreateFence)(vkGetInstanceProcAddr(instance, "vkCreateFence"));
+    vkDestroyFence = (PFN_vkDestroyFence)(vkGetInstanceProcAddr(instance, "vkDestroyFence"));
+    vkResetFences = (PFN_vkResetFences)(vkGetInstanceProcAddr(instance, "vkResetFences"));
+    vkGetFenceStatus = (PFN_vkGetFenceStatus)(vkGetInstanceProcAddr(instance, "vkGetFenceStatus"));
+    vkWaitForFences = (PFN_vkWaitForFences)(vkGetInstanceProcAddr(instance, "vkWaitForFences"));
+    vkCreateSemaphore = (PFN_vkCreateSemaphore)(vkGetInstanceProcAddr(instance, "vkCreateSemaphore"));
+    vkDestroySemaphore = (PFN_vkDestroySemaphore)(vkGetInstanceProcAddr(instance, "vkDestroySemaphore"));
+    vkCreateEvent = (PFN_vkCreateEvent)(vkGetInstanceProcAddr(instance, "vkCreateEvent"));
+    vkDestroyEvent = (PFN_vkDestroyEvent)(vkGetInstanceProcAddr(instance, "vkDestroyEvent"));
+    vkGetEventStatus = (PFN_vkGetEventStatus)(vkGetInstanceProcAddr(instance, "vkGetEventStatus"));
+    vkSetEvent = (PFN_vkSetEvent)(vkGetInstanceProcAddr(instance, "vkSetEvent"));
+    vkResetEvent = (PFN_vkResetEvent)(vkGetInstanceProcAddr(instance, "vkResetEvent"));
+    vkCreateQueryPool = (PFN_vkCreateQueryPool)(vkGetInstanceProcAddr(instance, "vkCreateQueryPool"));
+    vkDestroyQueryPool = (PFN_vkDestroyQueryPool)(vkGetInstanceProcAddr(instance, "vkDestroyQueryPool"));
+    vkGetQueryPoolResults = (PFN_vkGetQueryPoolResults)(vkGetInstanceProcAddr(instance, "vkGetQueryPoolResults"));
+    vkCreateBuffer = (PFN_vkCreateBuffer)(vkGetInstanceProcAddr(instance, "vkCreateBuffer"));
+    vkDestroyBuffer = (PFN_vkDestroyBuffer)(vkGetInstanceProcAddr(instance, "vkDestroyBuffer"));
+    vkCreateBufferView = (PFN_vkCreateBufferView)(vkGetInstanceProcAddr(instance, "vkCreateBufferView"));
+    vkDestroyBufferView = (PFN_vkDestroyBufferView)(vkGetInstanceProcAddr(instance, "vkDestroyBufferView"));
+    vkCreateImage = (PFN_vkCreateImage)(vkGetInstanceProcAddr(instance, "vkCreateImage"));
+    vkDestroyImage = (PFN_vkDestroyImage)(vkGetInstanceProcAddr(instance, "vkDestroyImage"));
+    vkGetImageSubresourceLayout = (PFN_vkGetImageSubresourceLayout)(vkGetInstanceProcAddr(instance, "vkGetImageSubresourceLayout"));
+    vkCreateImageView = (PFN_vkCreateImageView)(vkGetInstanceProcAddr(instance, "vkCreateImageView"));
+    vkDestroyImageView = (PFN_vkDestroyImageView)(vkGetInstanceProcAddr(instance, "vkDestroyImageView"));
+    vkCreateShaderModule = (PFN_vkCreateShaderModule)(vkGetInstanceProcAddr(instance, "vkCreateShaderModule"));
+    vkDestroyShaderModule = (PFN_vkDestroyShaderModule)(vkGetInstanceProcAddr(instance, "vkDestroyShaderModule"));
+    vkCreatePipelineCache = (PFN_vkCreatePipelineCache)(vkGetInstanceProcAddr(instance, "vkCreatePipelineCache"));
+    vkDestroyPipelineCache = (PFN_vkDestroyPipelineCache)(vkGetInstanceProcAddr(instance, "vkDestroyPipelineCache"));
+    vkGetPipelineCacheData = (PFN_vkGetPipelineCacheData)(vkGetInstanceProcAddr(instance, "vkGetPipelineCacheData"));
+    vkMergePipelineCaches = (PFN_vkMergePipelineCaches)(vkGetInstanceProcAddr(instance, "vkMergePipelineCaches"));
+    vkCreateGraphicsPipelines = (PFN_vkCreateGraphicsPipelines)(vkGetInstanceProcAddr(instance, "vkCreateGraphicsPipelines"));
+    vkCreateComputePipelines = (PFN_vkCreateComputePipelines)(vkGetInstanceProcAddr(instance, "vkCreateComputePipelines"));
+    vkDestroyPipeline = (PFN_vkDestroyPipeline)(vkGetInstanceProcAddr(instance, "vkDestroyPipeline"));
+    vkCreatePipelineLayout = (PFN_vkCreatePipelineLayout)(vkGetInstanceProcAddr(instance, "vkCreatePipelineLayout"));
+    vkDestroyPipelineLayout = (PFN_vkDestroyPipelineLayout)(vkGetInstanceProcAddr(instance, "vkDestroyPipelineLayout"));
+    vkCreateSampler = (PFN_vkCreateSampler)(vkGetInstanceProcAddr(instance, "vkCreateSampler"));
+    vkDestroySampler = (PFN_vkDestroySampler)(vkGetInstanceProcAddr(instance, "vkDestroySampler"));
+    vkCreateDescriptorSetLayout = (PFN_vkCreateDescriptorSetLayout)(vkGetInstanceProcAddr(instance, "vkCreateDescriptorSetLayout"));
+    vkDestroyDescriptorSetLayout = (PFN_vkDestroyDescriptorSetLayout)(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorSetLayout"));
+    vkCreateDescriptorPool = (PFN_vkCreateDescriptorPool)(vkGetInstanceProcAddr(instance, "vkCreateDescriptorPool"));
+    vkDestroyDescriptorPool = (PFN_vkDestroyDescriptorPool)(vkGetInstanceProcAddr(instance, "vkDestroyDescriptorPool"));
+    vkResetDescriptorPool = (PFN_vkResetDescriptorPool)(vkGetInstanceProcAddr(instance, "vkResetDescriptorPool"));
+    vkAllocateDescriptorSets = (PFN_vkAllocateDescriptorSets)(vkGetInstanceProcAddr(instance, "vkAllocateDescriptorSets"));
+    vkFreeDescriptorSets = (PFN_vkFreeDescriptorSets)(vkGetInstanceProcAddr(instance, "vkFreeDescriptorSets"));
+    vkUpdateDescriptorSets = (PFN_vkUpdateDescriptorSets)(vkGetInstanceProcAddr(instance, "vkUpdateDescriptorSets"));
+    vkCreateFramebuffer = (PFN_vkCreateFramebuffer)(vkGetInstanceProcAddr(instance, "vkCreateFramebuffer"));
+    vkDestroyFramebuffer = (PFN_vkDestroyFramebuffer)(vkGetInstanceProcAddr(instance, "vkDestroyFramebuffer"));
+    vkCreateRenderPass = (PFN_vkCreateRenderPass)(vkGetInstanceProcAddr(instance, "vkCreateRenderPass"));
+    vkDestroyRenderPass = (PFN_vkDestroyRenderPass)(vkGetInstanceProcAddr(instance, "vkDestroyRenderPass"));
+    vkGetRenderAreaGranularity = (PFN_vkGetRenderAreaGranularity)(vkGetInstanceProcAddr(instance, "vkGetRenderAreaGranularity"));
+    vkCreateCommandPool = (PFN_vkCreateCommandPool)(vkGetInstanceProcAddr(instance, "vkCreateCommandPool"));
+    vkDestroyCommandPool = (PFN_vkDestroyCommandPool)(vkGetInstanceProcAddr(instance, "vkDestroyCommandPool"));
+    vkResetCommandPool = (PFN_vkResetCommandPool)(vkGetInstanceProcAddr(instance, "vkResetCommandPool"));
+    vkAllocateCommandBuffers = (PFN_vkAllocateCommandBuffers)(vkGetInstanceProcAddr(instance, "vkAllocateCommandBuffers"));
+    vkFreeCommandBuffers = (PFN_vkFreeCommandBuffers)(vkGetInstanceProcAddr(instance, "vkFreeCommandBuffers"));
+    vkBeginCommandBuffer = (PFN_vkBeginCommandBuffer)(vkGetInstanceProcAddr(instance, "vkBeginCommandBuffer"));
+    vkEndCommandBuffer = (PFN_vkEndCommandBuffer)(vkGetInstanceProcAddr(instance, "vkEndCommandBuffer"));
+    vkResetCommandBuffer = (PFN_vkResetCommandBuffer)(vkGetInstanceProcAddr(instance, "vkResetCommandBuffer"));
+    vkCmdBindPipeline = (PFN_vkCmdBindPipeline)(vkGetInstanceProcAddr(instance, "vkCmdBindPipeline"));
+    vkCmdSetViewport = (PFN_vkCmdSetViewport)(vkGetInstanceProcAddr(instance, "vkCmdSetViewport"));
+    vkCmdSetScissor = (PFN_vkCmdSetScissor)(vkGetInstanceProcAddr(instance, "vkCmdSetScissor"));
+    vkCmdSetLineWidth = (PFN_vkCmdSetLineWidth)(vkGetInstanceProcAddr(instance, "vkCmdSetLineWidth"));
+    vkCmdSetDepthBias = (PFN_vkCmdSetDepthBias)(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBias"));
+    vkCmdSetBlendConstants = (PFN_vkCmdSetBlendConstants)(vkGetInstanceProcAddr(instance, "vkCmdSetBlendConstants"));
+    vkCmdSetDepthBounds = (PFN_vkCmdSetDepthBounds)(vkGetInstanceProcAddr(instance, "vkCmdSetDepthBounds"));
+    vkCmdSetStencilCompareMask = (PFN_vkCmdSetStencilCompareMask)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilCompareMask"));
+    vkCmdSetStencilWriteMask = (PFN_vkCmdSetStencilWriteMask)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilWriteMask"));
+    vkCmdSetStencilReference = (PFN_vkCmdSetStencilReference)(vkGetInstanceProcAddr(instance, "vkCmdSetStencilReference"));
+    vkCmdBindDescriptorSets = (PFN_vkCmdBindDescriptorSets)(vkGetInstanceProcAddr(instance, "vkCmdBindDescriptorSets"));
+    vkCmdBindIndexBuffer = (PFN_vkCmdBindIndexBuffer)(vkGetInstanceProcAddr(instance, "vkCmdBindIndexBuffer"));
+    vkCmdBindVertexBuffers = (PFN_vkCmdBindVertexBuffers)(vkGetInstanceProcAddr(instance, "vkCmdBindVertexBuffers"));
+    vkCmdDraw = (PFN_vkCmdDraw)(vkGetInstanceProcAddr(instance, "vkCmdDraw"));
+    vkCmdDrawIndexed = (PFN_vkCmdDrawIndexed)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexed"));
+    vkCmdDrawIndirect = (PFN_vkCmdDrawIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndirect"));
+    vkCmdDrawIndexedIndirect = (PFN_vkCmdDrawIndexedIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDrawIndexedIndirect"));
+    vkCmdDispatch = (PFN_vkCmdDispatch)(vkGetInstanceProcAddr(instance, "vkCmdDispatch"));
+    vkCmdDispatchIndirect = (PFN_vkCmdDispatchIndirect)(vkGetInstanceProcAddr(instance, "vkCmdDispatchIndirect"));
+    vkCmdCopyBuffer = (PFN_vkCmdCopyBuffer)(vkGetInstanceProcAddr(instance, "vkCmdCopyBuffer"));
+    vkCmdCopyImage = (PFN_vkCmdCopyImage)(vkGetInstanceProcAddr(instance, "vkCmdCopyImage"));
+    vkCmdBlitImage = (PFN_vkCmdBlitImage)(vkGetInstanceProcAddr(instance, "vkCmdBlitImage"));
+    vkCmdCopyBufferToImage = (PFN_vkCmdCopyBufferToImage)(vkGetInstanceProcAddr(instance, "vkCmdCopyBufferToImage"));
+    vkCmdCopyImageToBuffer = (PFN_vkCmdCopyImageToBuffer)(vkGetInstanceProcAddr(instance, "vkCmdCopyImageToBuffer"));
+    vkCmdUpdateBuffer = (PFN_vkCmdUpdateBuffer)(vkGetInstanceProcAddr(instance, "vkCmdUpdateBuffer"));
+    vkCmdFillBuffer = (PFN_vkCmdFillBuffer)(vkGetInstanceProcAddr(instance, "vkCmdFillBuffer"));
+    vkCmdClearColorImage = (PFN_vkCmdClearColorImage)(vkGetInstanceProcAddr(instance, "vkCmdClearColorImage"));
+    vkCmdClearDepthStencilImage = (PFN_vkCmdClearDepthStencilImage)(vkGetInstanceProcAddr(instance, "vkCmdClearDepthStencilImage"));
+    vkCmdClearAttachments = (PFN_vkCmdClearAttachments)(vkGetInstanceProcAddr(instance, "vkCmdClearAttachments"));
+    vkCmdResolveImage = (PFN_vkCmdResolveImage)(vkGetInstanceProcAddr(instance, "vkCmdResolveImage"));
+    vkCmdSetEvent = (PFN_vkCmdSetEvent)(vkGetInstanceProcAddr(instance, "vkCmdSetEvent"));
+    vkCmdResetEvent = (PFN_vkCmdResetEvent)(vkGetInstanceProcAddr(instance, "vkCmdResetEvent"));
+    vkCmdWaitEvents = (PFN_vkCmdWaitEvents)(vkGetInstanceProcAddr(instance, "vkCmdWaitEvents"));
+    vkCmdPipelineBarrier = (PFN_vkCmdPipelineBarrier)(vkGetInstanceProcAddr(instance, "vkCmdPipelineBarrier"));
+    vkCmdBeginQuery = (PFN_vkCmdBeginQuery)(vkGetInstanceProcAddr(instance, "vkCmdBeginQuery"));
+    vkCmdEndQuery = (PFN_vkCmdEndQuery)(vkGetInstanceProcAddr(instance, "vkCmdEndQuery"));
+    vkCmdResetQueryPool = (PFN_vkCmdResetQueryPool)(vkGetInstanceProcAddr(instance, "vkCmdResetQueryPool"));
+    vkCmdWriteTimestamp = (PFN_vkCmdWriteTimestamp)(vkGetInstanceProcAddr(instance, "vkCmdWriteTimestamp"));
+    vkCmdCopyQueryPoolResults = (PFN_vkCmdCopyQueryPoolResults)(vkGetInstanceProcAddr(instance, "vkCmdCopyQueryPoolResults"));
+    vkCmdPushConstants = (PFN_vkCmdPushConstants)(vkGetInstanceProcAddr(instance, "vkCmdPushConstants"));
+    vkCmdBeginRenderPass = (PFN_vkCmdBeginRenderPass)(vkGetInstanceProcAddr(instance, "vkCmdBeginRenderPass"));
+    vkCmdNextSubpass = (PFN_vkCmdNextSubpass)(vkGetInstanceProcAddr(instance, "vkCmdNextSubpass"));
+    vkCmdEndRenderPass = (PFN_vkCmdEndRenderPass)(vkGetInstanceProcAddr(instance, "vkCmdEndRenderPass"));
+    vkCmdExecuteCommands = (PFN_vkCmdExecuteCommands)(vkGetInstanceProcAddr(instance, "vkCmdExecuteCommands"));
+    vkDestroySurfaceKHR = (PFN_vkDestroySurfaceKHR)(vkGetInstanceProcAddr(instance, "vkDestroySurfaceKHR"));
+    vkGetPhysicalDeviceSurfaceSupportKHR = (PFN_vkGetPhysicalDeviceSurfaceSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceSupportKHR"));
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR = (PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR"));
+    vkGetPhysicalDeviceSurfaceFormatsKHR = (PFN_vkGetPhysicalDeviceSurfaceFormatsKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceFormatsKHR"));
+    vkGetPhysicalDeviceSurfacePresentModesKHR = (PFN_vkGetPhysicalDeviceSurfacePresentModesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModesKHR"));
+    vkCreateSwapchainKHR = (PFN_vkCreateSwapchainKHR)(vkGetInstanceProcAddr(instance, "vkCreateSwapchainKHR"));
+    vkDestroySwapchainKHR = (PFN_vkDestroySwapchainKHR)(vkGetInstanceProcAddr(instance, "vkDestroySwapchainKHR"));
+    vkGetSwapchainImagesKHR = (PFN_vkGetSwapchainImagesKHR)(vkGetInstanceProcAddr(instance, "vkGetSwapchainImagesKHR"));
+    vkAcquireNextImageKHR = (PFN_vkAcquireNextImageKHR)(vkGetInstanceProcAddr(instance, "vkAcquireNextImageKHR"));
+    vkQueuePresentKHR = (PFN_vkQueuePresentKHR)(vkGetInstanceProcAddr(instance, "vkQueuePresentKHR"));
+    vkGetPhysicalDeviceDisplayPropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPropertiesKHR"));
+    vkGetPhysicalDeviceDisplayPlanePropertiesKHR = (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR"));
+    vkGetDisplayPlaneSupportedDisplaysKHR = (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayPlaneSupportedDisplaysKHR"));
+    vkGetDisplayModePropertiesKHR = (PFN_vkGetDisplayModePropertiesKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayModePropertiesKHR"));
+    vkCreateDisplayModeKHR = (PFN_vkCreateDisplayModeKHR)(vkGetInstanceProcAddr(instance, "vkCreateDisplayModeKHR"));
+    vkGetDisplayPlaneCapabilitiesKHR = (PFN_vkGetDisplayPlaneCapabilitiesKHR)(vkGetInstanceProcAddr(instance, "vkGetDisplayPlaneCapabilitiesKHR"));
+    vkCreateDisplayPlaneSurfaceKHR = (PFN_vkCreateDisplayPlaneSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateDisplayPlaneSurfaceKHR"));
+    vkCreateSharedSwapchainsKHR = (PFN_vkCreateSharedSwapchainsKHR)(vkGetInstanceProcAddr(instance, "vkCreateSharedSwapchainsKHR"));
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-    vkCreateXlibSurfaceKHR = reinterpret_cast<PFN_vkCreateXlibSurfaceKHR>(dlsym(libvulkan, "vkCreateXlibSurfaceKHR"));
-    vkGetPhysicalDeviceXlibPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
+    vkCreateXlibSurfaceKHR = (PFN_vkCreateXlibSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR"));
+    vkGetPhysicalDeviceXlibPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-    vkCreateXcbSurfaceKHR = reinterpret_cast<PFN_vkCreateXcbSurfaceKHR>(dlsym(libvulkan, "vkCreateXcbSurfaceKHR"));
-    vkGetPhysicalDeviceXcbPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
+    vkCreateXcbSurfaceKHR = (PFN_vkCreateXcbSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR"));
+    vkGetPhysicalDeviceXcbPresentationSupportKHR = (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-    vkCreateWaylandSurfaceKHR = reinterpret_cast<PFN_vkCreateWaylandSurfaceKHR>(dlsym(libvulkan, "vkCreateWaylandSurfaceKHR"));
-    vkGetPhysicalDeviceWaylandPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
+    vkCreateWaylandSurfaceKHR = (PFN_vkCreateWaylandSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR"));
+    vkGetPhysicalDeviceWaylandPresentationSupportKHR = (PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceWaylandPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_MIR_KHR
-    vkCreateMirSurfaceKHR = reinterpret_cast<PFN_vkCreateMirSurfaceKHR>(dlsym(libvulkan, "vkCreateMirSurfaceKHR"));
-    vkGetPhysicalDeviceMirPresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceMirPresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceMirPresentationSupportKHR"));
+    vkCreateMirSurfaceKHR = (PFN_vkCreateMirSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateMirSurfaceKHR"));
+    vkGetPhysicalDeviceMirPresentationSupportKHR = (PFN_vkGetPhysicalDeviceMirPresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceMirPresentationSupportKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    vkCreateAndroidSurfaceKHR = reinterpret_cast<PFN_vkCreateAndroidSurfaceKHR>(dlsym(libvulkan, "vkCreateAndroidSurfaceKHR"));
+    vkCreateAndroidSurfaceKHR = (PFN_vkCreateAndroidSurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateAndroidSurfaceKHR"));
 #endif
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    vkCreateWin32SurfaceKHR = reinterpret_cast<PFN_vkCreateWin32SurfaceKHR>(dlsym(libvulkan, "vkCreateWin32SurfaceKHR"));
-    vkGetPhysicalDeviceWin32PresentationSupportKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR>(dlsym(libvulkan, "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
+    vkCreateWin32SurfaceKHR = (PFN_vkCreateWin32SurfaceKHR)(vkGetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR"));
+    vkGetPhysicalDeviceWin32PresentationSupportKHR = (PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR)(vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceWin32PresentationSupportKHR"));
 #endif
 #ifdef USE_DEBUG_EXTENTIONS
-    vkCreateDebugReportCallbackEXT = reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>(dlsym(libvulkan, "vkCreateDebugReportCallbackEXT"));
-    vkDestroyDebugReportCallbackEXT = reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>(dlsym(libvulkan, "vkDestroyDebugReportCallbackEXT"));
-    vkDebugReportMessageEXT = reinterpret_cast<PFN_vkDebugReportMessageEXT>(dlsym(libvulkan, "vkDebugReportMessageEXT"));
+    vkCreateDebugReportCallbackEXT = (PFN_vkCreateDebugReportCallbackEXT)(vkGetInstanceProcAddr(instance, "vkCreateDebugReportCallbackEXT"));
+    vkDestroyDebugReportCallbackEXT = (PFN_vkDestroyDebugReportCallbackEXT)(vkGetInstanceProcAddr(instance, "vkDestroyDebugReportCallbackEXT"));
+    vkDebugReportMessageEXT = (PFN_vkDebugReportMessageEXT)(vkGetInstanceProcAddr(instance, "vkDebugReportMessageEXT"));
 #endif
     return 1;
 }
+
 
 // No Vulkan support, do not set function addresses
 PFN_vkCreateInstance vkCreateInstance;

--- a/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
+++ b/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
@@ -51,15 +51,9 @@ int LoadInstanceProcs(VkInstance instance);
  * @return 0 if failed to init Vulkan
  */
 int InitVulkan(void) {
-#ifdef _WIN32
-    #define LoadProcAddress GetProcAddress
-    HINSTANCE  libvulkan = NULL;    
-    libvulkan = LoadLibrary("vulkan-1.dll");   
-#else  // all *nix
     #define LoadProcAddress dlsym
     void* libvulkan = nullptr;    
     libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	
-#endif    
     
     if (!libvulkan)
         return 0;

--- a/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
+++ b/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.cpp
@@ -21,13 +21,8 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 #include "vulkan_wrapper.h"
+#include <dlfcn.h>
 
-#ifdef _WIN32
-   #include <windows.h>
-   #include <wchar.h>
-#else
-   #include <dlfcn.h>
-#endif
 
 // a hook to Vulkan native function
 static PFN_vkCreateInstance vkCreateInstance_HOOK;
@@ -53,7 +48,7 @@ int LoadInstanceProcs(VkInstance instance);
 int InitVulkan(void) {
     #define LoadProcAddress dlsym
     void* libvulkan = nullptr;    
-    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	
+    libvulkan = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);	  
     
     if (!libvulkan)
         return 0;

--- a/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.h
+++ b/tutorial01_load_vulkan/app/src/main/jni/vulkan_wrapper.h
@@ -19,10 +19,19 @@
 #define VK_NO_PROTOTYPES 1
 #include <vulkan/vulkan.h>
 
-/* Initialize the Vulkan function pointer variables declared in this header.
- * Returns 0 if vulkan is not available, non-zero if it is available.
+/** 
+ * Initialize Vulkan function pointer variables declared in this header.
+ * After call, following functions will be available:
+ *  vkEnumerateInstanceExtensionProperties
+ *  vkEnumerateInstanceLayerProperties
+ *  vkCreateInstance
+ *  
+ * Note: core functions will be available after vkCreateInstance() call.
+ *
+ * @returns 0 if vulkan is not available, non-zero otherwise.
  */
-int InitVulkan(void);
+extern int InitVulkan(void);
+
 
 // VK_core
 extern PFN_vkCreateInstance vkCreateInstance;


### PR DESCRIPTION
Hi !
I'd like to submit an enhancement to vulkan_wrapper.
Basically, it replaces all Vulkan procedure loading with **dlsym** by a more specification friendly loading method with **vkGetInstanceProcAddr**. Exception is on vkGetInstanceProcAddr itself, which is the unique Vulkan function loaded with dlsym.

Once **vkGetInstanceProcAddr** is loaded, it can be used to load the following functions, passing instance parameter as nullptr : 
- vkEnumerateInstanceExtensionProperties
- vkEnumerateInstanceLayerProperties
-  vkCreateInstance

A live instance of VkInstance, necessary to load all core and enabled extension functions, will be available only after a call to **vkCreateInstance**.
So I proposed a Delegate vkCreateInstance, which will do a double job: 
(i) call the the real one function (keep by vkCreateInstance_HOOK) and (ii) call a function to load all remaining core and enabled extension functions.

**Reason**
Vulkan spec states the following, at Chapter 3:

> Vulkan commands are not necessarily exposed statically on a platform. Function pointers for all Vulkan commands can be obtained with the command: 
> 
> ```
>  PFN_vkVoidFunction vkGetInstanceProcAddr( 
>                    VkInstance instance,
>                    const char* pName);
> ```

With proposed fix, we attend the specification and avoid issues with Vulkan drivers which only exposes  **vkGetInstanceProcAddr** . 
Same apply to extension functions (the vk \* EXT and vk \* KHR functions). Those functions should be available only when enabled through VkInstanceCreateInfo.ppEnabledExtensionNames at VkInstance creation. 
