### PR TITLE
Fix NDK 14 layer source code relocation issue for tutorial03

### DIFF
--- a/tutorial02_prebuild_layers/README.md
+++ b/tutorial02_prebuild_layers/README.md
@@ -1,6 +1,14 @@
 Tutorial 02 - use validation layers - 1
 ===========
-Add ndk-build for validation layers into gradle and pack them into apk
-Enable all validation layers/extensions found on the system
-Using vulkan wrappers in common/vulkan_wrapper directory
+1. Add validation layers into gradle and pack them into apk
+1. Enable all validation layers/extensions found on the system
+1. Use vulkan wrappers in common/vulkan_wrapper directory
+
+Verification
+============
+Planted error: this sample sets VkDeviceQueueCreateInfo::pQueuePriorities to nullptr,
+which will trigger validation layers to notify us from registered callback function
+vkDebugReportCallbackEX_impl(); putting a breakpoint with Android Studo, observe
+the breakpoint being triggered.
+
 

--- a/tutorial03_traceable_layers/layerlib/CMakeLists.txt
+++ b/tutorial03_traceable_layers/layerlib/CMakeLists.txt
@@ -118,9 +118,13 @@ if(${ANDROID_NDK_REVISION} LESS 13)
     set(unique_objects_SRCS
             ${LAYER_DIR}/layer-src/unique_objects/unique_objects.cpp
             ${LAYER_DIR}/layer-src/unique_objects/vk_safe_struct.cpp)
-else(${ANDROID_NDK_REVISION} LESS 13 )
+elseif (${ANDROID_NDK_REVISION} LESS 14 )
     set(unique_objects_SRCS
             ${LAYER_DIR}/include/unique_objects.cpp
+            ${LAYER_DIR}/include/vk_safe_struct.cpp)
+else()
+    set(unique_objects_SRCS
+            ${SRC_DIR}/layers/unique_objects.cpp
             ${LAYER_DIR}/include/vk_safe_struct.cpp)
 endif(${ANDROID_NDK_REVISION} LESS 13 )
 list(APPEND unique_objects_SRCS ${SRC_DIR}/layers/vk_layer_table.cpp)


### PR DESCRIPTION
I think this fix the issue: https://github.com/googlesamples/android-vulkan-tutorials/issues/20

mainly layer sources moved around in NDK among versions.  after this, probably need find a way to get cmake into ndk's layer directory.

@cnorthrop @tobine, please take a look, thank you a lot!