### PR TITLE
Retire application.mk and use command line parameters for shaderc build

### DIFF
--- a/tutorial03_traceable_layers/app/build.gradle
+++ b/tutorial03_traceable_layers/app/build.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'com.android.application'
 
-Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-def ndkDir = properties.getProperty('ndk.dir')
-
 android {
         compileSdkVersion 24
-        buildToolsVersion "24.0.0"
+        buildToolsVersion '25.0.0'
 
         defaultConfig {
             applicationId "com.google.vulkan.tutorials.three"
@@ -14,19 +10,12 @@ android {
             targetSdkVersion 24
             versionCode = 1
             versionName = "0.0.1"
-            externalNativeBuild {
-                cmake {
-                    abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-                    arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=gnustl_static'
-                }
-            }
+            ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+            externalNativeBuild.cmake.arguments '-DANDROID_TOOLCHAIN=clang',
+                                                '-DANDROID_STL=gnustl_static'
         }
 
-        externalNativeBuild {
-            cmake {
-                path 'CMakeLists.txt'
-            }
-        }
+        externalNativeBuild.cmake.path 'CMakeLists.txt'
 
         sourceSets {
             main {

--- a/tutorial03_traceable_layers/build.gradle
+++ b/tutorial03_traceable_layers/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-rc2'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial03_traceable_layers/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial03_traceable_layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 12 17:03:20 PDT 2016
+#Tue May 23 17:18:13 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/tutorial03_traceable_layers/layerlib/Application.mk
+++ b/tutorial03_traceable_layers/layerlib/Application.mk
@@ -1,7 +1,0 @@
-APP_ABI := armeabi-v7a arm64-v8a x86 x86_64 mips mips64
-APP_PLATFORM := android-24
-# Shaderc builds the libs into a directory with APP_STL being part of it
-# CMakeLists.ext would need to be updated if stl type is changed
-APP_STL := gnustl_static
-NDK_TOOLCHAIN_VERSION := clang
-

--- a/tutorial03_traceable_layers/layerlib/CMakeLists.txt
+++ b/tutorial03_traceable_layers/layerlib/CMakeLists.txt
@@ -39,19 +39,29 @@ if(NOT (${ANDROID_NDK_REVISION} LESS 13))
     include_directories(${NDK_SRC_DIR}/third_party/shaderc/third_party/glslang
                         ${NDK_SRC_DIR}/third_party/shaderc/third_party/spirv-tools/include)
 
-    set(SHADERC_OUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/shaderc)
+    set(SHADERC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/build/shaderc)
     set(lib_shaderc ${SHADERC_OUT_DIR}/gnustl_static/${ANDROID_ABI}/libshaderc.a)
     set(SHADERC_SRC_DIR ${NDK_SRC_DIR}/third_party/shaderc)
+
+    set(NDK_TOOLCHAIN_CFG ${ANDROID_TOOLCHAIN})
+    string(TOLOWER "${NDK_TOOLCHAIN_CFG}" NDK_TOOLCHAIN_CFG)
+    if(${ANDROID_TOOLCHAIN} STREQUAL "gcc")
+        set(NDK_TOOLCHAIN_CFG "4.9")
+    endif()
+
     if(CMAKE_HOST_WIN32)
         ExternalProject_Add(BuildShaderc
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ${ANDROID_NDK}/ndk-build.cmd --jobs=8 NDK_DEBUG=1
-                          NDK_PROJECT_PATH=${SHADERC_SRC_DIR}
-                          NDK_OUT=./shaderc NDK_LIBS_OUT=${SHADERC_OUT_DIR}
-                          NDK_APPLICATION_MK=${CMAKE_CURRENT_SOURCE_DIR}/Application.mk
-                          APP_BUILD_SCRIPT=${SHADERC_SRC_DIR}/Android.mk
-                          libshaderc_combined
+                NDK_PROJECT_PATH=${SHADERC_SRC_DIR}
+                NDK_LIBS_OUT=${SHADERC_OUT_DIR}
+                APP_ABI=${ANDROID_ABI}
+                APP_PLATFORM=${ANDROID_PLATFORM}
+                APP_STL=${ANDROID_STL}
+                NDK_TOOLCHAIN_VERSION=${NDK_TOOLCHAIN_CFG}
+                APP_BUILD_SCRIPT=${SHADERC_SRC_DIR}/Android.mk
+                libshaderc_combined
             LOG_CONFIGURE 1
             BUILD_ALWAYS 1
             LOG_BUILD    1
@@ -62,11 +72,14 @@ if(NOT (${ANDROID_NDK_REVISION} LESS 13))
             SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
             CONFIGURE_COMMAND mkdir -p ${SHADERC_OUT_DIR}
             BUILD_COMMAND ${ANDROID_NDK}/ndk-build --jobs=8 NDK_DEBUG=1
-                          NDK_PROJECT_PATH=${SHADERC_SRC_DIR}
-                          NDK_LIBS_OUT=${SHADERC_OUT_DIR}
-                          NDK_APPLICATION_MK=${CMAKE_CURRENT_SOURCE_DIR}/Application.mk
-                          APP_BUILD_SCRIPT=${SHADERC_SRC_DIR}/Android.mk
-                          libshaderc_combined     # make the combined lib to use
+                NDK_PROJECT_PATH=${SHADERC_SRC_DIR}
+                NDK_LIBS_OUT=${SHADERC_OUT_DIR}
+                APP_ABI=${ANDROID_ABI}
+                APP_PLATFORM=${ANDROID_PLATFORM}
+                APP_STL=${ANDROID_STL}
+                NDK_TOOLCHAIN_VERSION=${NDK_TOOLCHAIN_CFG}
+                APP_BUILD_SCRIPT=${SHADERC_SRC_DIR}/Android.mk
+                libshaderc_combined     # make the combined lib to use
             BUILD_ALWAYS 1    # Force build
             BUILD_BYPRODUCTS ${lib_shaderc}
             INSTALL_COMMAND "")

--- a/tutorial03_traceable_layers/layerlib/build.gradle
+++ b/tutorial03_traceable_layers/layerlib/build.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'com.android.library'
 
 // Both cmake and ndkbuild are simple, pick one and feel free to remove the
-// other one. This code is tested against Android Studio 2.2 + NDK-r12/NDK-r13
-// [Android Studio 2.2.0-beta1 + NDK-r13-beta1 + SDK_cmake_3.6 does not work]
-// control to switch:
+// other one. This code is tested against Android Studio 2.3 + NDK-r14
 // USE_CMAKE = 0 :  use ndkbuild plugin to build layers ( does not work with windows )
 // USE_CMAKE = 1 :  use cmake plugin to build layers
 def USE_CMAKE = 1
@@ -12,54 +10,35 @@ android {
     /*
      * we are interested in only the debug version of layers, so ONLY publish debug version
      * library, which will enforce building ONLY debug version, and packing only the debug
-     * version of layers. The document is at:
+     * version of layers. Some document is at:
      *     https://developer.android.com/studio/build/build-variants.html
      *     http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Library-Publication
-     *  (unfortunately, following both docs exactly could not get work done, not sure what is missed)
      */
     publishNonDefault  true
 
     compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         externalNativeBuild {
             if (USE_CMAKE) {
-                cmake {
-                    abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64', 'mips'
-                    arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=gnustl_static'
-                    if (System.properties['os.name'].toLowerCase().contains('windows')) {
-                        // On windows, have to use gcc to build layers
-                        arguments '-DANDROID_TOOLCHAIN=gcc'
-                    }
-                }
+                cmake.arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=gnustl_static'
             } else {
-                ndkBuild {
-                    arguments 'NDK_DEBUG=1'
-                    abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64', 'mips'
-                }
+                ndkBuild.arguments 'NDK_DEBUG=1'
             }
         }
     }
     externalNativeBuild {
         if (USE_CMAKE) {
-            cmake {
-                path 'CMakeLists.txt'
-            }
+            cmake.path 'CMakeLists.txt'
         } else {
-            ndkBuild {
-                // Make sure NDK_TOOLCHAIN_VERSION & APP_STL are set to the same one
-                // as app module
-                Properties properties = new Properties()
-                properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                def ndkDir = properties.getProperty('ndk.dir')
-
-                path "${ndkDir}/sources/third_party/vulkan/src/build-android/jni/Android.mk"
-            }
+            ndkBuild.path android.ndkDirectory +
+                    "/sources/third_party/vulkan/src/build-android/jni/Android.mk"
         }
     }
     buildTypes {


### PR DESCRIPTION
No functional change, only clean-up build scripts.
Tested on Mac and windows 10, ran on Pixel XL Android O Developer Preview
