### PR TITLE
minor tutorial06 fix: force 4 channels when loading images

### DIFF
--- a/tutorial06_texture/app/src/main/cpp/VulkanMain.cpp
+++ b/tutorial06_texture/app/src/main/cpp/VulkanMain.cpp
@@ -367,7 +367,8 @@ VkResult LoadTextureFromFile(const char* filePath,
   uint32_t imgWidth, imgHeight, n;
   unsigned char* imageData = stbi_load_from_memory(
       fileContent, fileLength, reinterpret_cast<int*>(&imgWidth),
-      reinterpret_cast<int*>(&imgHeight), reinterpret_cast<int*>(&n), 0);
+      reinterpret_cast<int*>(&imgHeight), reinterpret_cast<int*>(&n), 4);
+  assert(n == 4);
 
   tex_obj->tex_width = imgWidth;
   tex_obj->tex_height = imgHeight;


### PR DESCRIPTION
the code copying image out from stbi buffer to VK image buffer assumes 4 channels, if texture file just 3 channels, it will be trouble. Just add forcefully request 4 channels from loader and assert we do get 4.  Merging in for this small change