### PR TITLE
Tutorial 3 to new dependency configurations

### DIFF
--- a/tutorial03_traceable_layers/layerlib/build.gradle
+++ b/tutorial03_traceable_layers/layerlib/build.gradle
@@ -40,10 +40,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:24.1.1'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
When running the Tutorial 3 `build.gradle` I get deprecated warnings for `compile`, `testCompile`, and `androidTestCompile`

[Android New Configurations](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html?utm_source=android-studio#new_configurations)