### PR TITLE
Update build script for Validation Layer downloading

### DIFF
--- a/tutorial02_prebuild_layers/app/build.gradle
+++ b/tutorial02_prebuild_layers/app/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.application'
  * 1. remove the pre-downloaded dir(if exists): rm -fr $projectRoot.layerLibs
  * 2. update the version number for ${LAYER_VERSION} in the following line:
  */
-def LAYER_VERSION = "1.2.176.0"
+def LAYER_VERSION = "1.3.231.1"
 
 // Variables shared between download layer binary and project build script.
 def LAYER_SITE ="https://github.com/KhronosGroup/Vulkan-ValidationLayers"
@@ -74,6 +74,7 @@ android {
         }
     }
     buildFeatures.prefab = true
+    namespace 'com.android.example.vulkan.tutorials.two'
 }
 
 dependencies {

--- a/tutorial02_prebuild_layers/app/build.gradle
+++ b/tutorial02_prebuild_layers/app/build.gradle
@@ -1,48 +1,18 @@
 apply plugin: 'com.android.application'
 
-/**
- * Download validation layer binary release zip file from Khronos github repo
- *    https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases
- * Note that: binary release could be manually downloaded and put it into
- *            jniLibs directory. This is just to do it automatically in case
- *            someday want to use github action continuous CI.
- * The release file name we are interested is in the format of
- *    android-binaries-${VERSION}.zip
- * When you need to use the latest release, do these:
- * 1. remove the pre-downloaded dir(if exists): rm -fr $projectRoot.layerLibs
- * 2. update the version number for ${LAYER_VERSION} in the following line:
- */
-def LAYER_VERSION = "1.3.231.1"
-
-// Variables shared between download layer binary and project build script.
-def LAYER_SITE ="https://github.com/KhronosGroup/Vulkan-ValidationLayers"
-def LAYER_LIB_ROOT= rootDir.absolutePath.toString() + "/layerLib"
-def LAYER_JNILIB_DIR="${LAYER_LIB_ROOT}/jniLibs"
-
-// Download the release zip file to ${LAYER_LIB_ROOT}/
-task download {
-    mkdir "${LAYER_LIB_ROOT}"
-    def f = new File("${LAYER_LIB_ROOT}/android-binaries-${LAYER_VERSION}.zip")
-    new URL("${LAYER_SITE}/releases/download/sdk-${LAYER_VERSION}/android-binaries-${LAYER_VERSION}.zip")
-            .withInputStream { i -> f.withOutputStream { it << i } }
-}
-
-// Unzip the downloaded release file to ${LAYER_JNILIB_DIR}, it is place for APK packing.
-task unzip(dependsOn: download, type: Copy) {
-    from zipTree(file("${LAYER_LIB_ROOT}/android-binaries-${LAYER_VERSION}.zip"))
-    into file("${LAYER_JNILIB_DIR}")
-}
+// Download validation layers from
+//     https://github.com/KhronosGroup/Vulkan-ValidationLayers
+ext.vvl_version='1.3.231.1'
+apply from: 'download_vvl.gradle'
 
 // This project's build scripts follows
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     ndkVersion '22.1.7171670'
-
     defaultConfig {
         applicationId "com.android.example.vulkan.tutorials.two"
         minSdkVersion 26
         targetSdkVersion 31
-
         versionCode  272
         versionName  "1.1.0"
         externalNativeBuild {
@@ -59,31 +29,11 @@ android {
         }
     }
 
-    sourceSets {
-        main {
-            jniLibs {
-              // Pre-requirement: layer release downloaded and unzip to this location
-              srcDirs = ["${LAYER_JNILIB_DIR}"]
-            }
-        }
-    }
-
-    buildTypes {
-        release {
-             minifyEnabled = false
-        }
-    }
     buildFeatures.prefab = true
     namespace 'com.android.example.vulkan.tutorials.two'
 }
 
 dependencies {
-    def jniFile = "${LAYER_JNILIB_DIR}/arm64-v8a/libVkLayer_khronos_validation.so"
-    if(!file("${jniFile}").exists()) {
-        implementation files("${jniFile}") {
-            builtBy 'unzip'
-        }
-    }
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.games:games-activity:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.games:games-activity:1.2.2"
 }

--- a/tutorial02_prebuild_layers/app/download_vvl.gradle
+++ b/tutorial02_prebuild_layers/app/download_vvl.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'com.android.application'
+/**
+ * Download validation layer binary release zip file from Khronos github repo
+ *    https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases
+ *
+ * To use this script, simple add the following to your module build.gradle:
+ *     apply from: "${PATH-TO-THIS}/download_vvl.gradle"
+ * Note: binary release can also be manually downloaded and put it into
+ *       the default jniLibs directory at app/src/main/jniLibs.
+ */
+
+// validation layer version to download. To update to a new version:
+//   - change the VVL_VER to a new version string.
+//   - delete directory pointed by ${VVL_JNILIB_DIR}.
+//   - sync gradle script in IDE and rebuild project.
+def VVL_VER = "1.3.231.1.321"
+if (ext.has("vvl_version")) {
+    VVL_VER = ext.vvl_version
+}
+
+println("======vvl_ver: ${VVL_VER}")
+
+// variables shared between download validation layer release and the project script.
+def VVL_SITE ="https://github.com/KhronosGroup/Vulkan-ValidationLayers"
+def VVL_LIB_ROOT= rootDir.absolutePath.toString() + "/layerLib"
+def VVL_JNILIB_DIR="${VVL_LIB_ROOT}/jniLibs"
+def VVL_SO_NAME = "libVkLayer_khronos_validation.so"
+
+// download the release zip file to ${VVL_LIB_ROOT}/
+task download {
+    def VVL_ZIP_NAME = "releases/download/sdk-${VVL_VER}/android-binaries-${VVL_VER}.zip"
+    mkdir "${VVL_LIB_ROOT}"
+    def f = new File("${VVL_LIB_ROOT}/android-binaries-${VVL_VER}.zip")
+    new URL("${VVL_SITE}/${VVL_ZIP_NAME}")
+        .withInputStream { i -> f.withOutputStream { it << i } }
+}
+
+// unzip the downloaded VVL zip to the ${VVL_JNILIB_DIR} for APK packaging.
+task unzip(dependsOn: download, type: Copy) {
+    from zipTree(file("${VVL_LIB_ROOT}/android-binaries-${VVL_VER}.zip"))
+    into file("${VVL_JNILIB_DIR}")
+}
+android.sourceSets.main.jniLibs {
+        srcDirs += ["${VVL_JNILIB_DIR}"]
+}
+
+// add vvl download as an application dependency.
+dependencies {
+    def ARM64_VVL_FILE = "${VVL_JNILIB_DIR}/arm64-v8a/${VVL_SO_NAME}"
+    if(!file("${ARM64_VVL_FILE}").exists()) {
+        implementation files("${ARM64_VVL_FILE}") {
+            builtBy 'unzip'
+        }
+    }
+}
+

--- a/tutorial02_prebuild_layers/app/src/main/AndroidManifest.xml
+++ b/tutorial02_prebuild_layers/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.android.example.vulkan.tutorials.two"
     android:versionCode="272"
     android:versionName="1.1.0">
 

--- a/tutorial02_prebuild_layers/build.gradle
+++ b/tutorial02_prebuild_layers/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial02_prebuild_layers/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial02_prebuild_layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Just to separate the validation layer downloading to its own script file. No functionality changes.

Tested: Pixel 3XL + Android 12.