### PR TITLE
Update AGP, NDK, CMake, and other dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 Tutorial Samples
 ================
-A set of samples to illustrate Vulkan API on Android with Android Studio		
-To build on windows for tutorial02/03, copy/install ndk-r12 ( or better ) to a directory close to root dir ( C: ) to workaround command path 260 character limit issue; see tutorial02/03's build.gradle for details. To Build samples:
-- Inside Andriod, menu File --> New --> Import Project
-- Find your sample's build.gradle and open it
-This will force andrioid studio to create local.properties file to config your SDK and NDK location; if you see error during importing, open local.properties file and correct the NDK and SDK location, then re-sync.
+A set of samples to illustrate Vulkan API on Android with Android Studio.
+
+To build the samples:
+- Inside Android Studio, use File --> New --> Import Project
+- Find your sample's directory or `build.gradle` file, and open it
+
+This will force Andrioid Studio to create local.properties file to config your SDK location. If you see
+an Android SDK error during importing, you can open local.properties file and correct the SDK path.
 
 Other Resources:	
 Additional Android Studio/NDK samples:    
@@ -31,19 +34,25 @@ Refer to README.md under its directory
 
 Pre-requisites
 --------------
-- A device running Android 7.0 (API level 24) or higher
-- [Android Studio 3.0](https://developer.android.com/studio/index.html) or higher
-- Android NDK
+- A device running Android 8.0 (API level 26) or higher
+- [Android Studio Jellyfish](https://developer.android.com/studio/index.html) or higher
+- Android NDK r25c
     * [NDK](https://developer.android.com/ndk/downloads/index.html)
-    * SDK with the latest cmake package
+- CMake 3.22.1 from Android SDK
 
 Test Matrix
 ------------
-| Andrid Studio Version | cmake in SDK| NDK      | device  |
-|-----------------------|-------------|----------|---------|
-| 3.0.0                 | 3.6.4111459 | NDK-r16  | Pixel XL|
+| Andrid Studio         | CMake       | NDK      | Device          | API Level |
+|-----------------------|-------------|----------|-----------------|-----------|
+| Jellyfish 2023.3.1    | 3.22.1      | r25c     | Pixel 7 Pro     | 34        |
+| Jellyfish 2023.3.1    | 3.22.1      | r25c     | x86_64 Emulator | 31        |
 
-Known Issue:
+
+Known Issues
+------------
+
+On Windows, if you hit the maximum 260 character path limit issue, copy/install the NDK
+to a directory close to the file system root (e.g., `C:`).
 
 Getting Started
 ---------------
@@ -52,7 +61,7 @@ Getting Started
 
 License
 -------
-Copyright 2016 Google, Inc.
+Copyright 2024 Google, Inc.
 
 Licensed to the Apache Software Foundation (ASF) under one or more contributor
 license agreements.  See the NOTICE file distributed with this work for

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Pre-requisites
 
 Test Matrix
 ------------
-| Andrid Studio         | CMake       | NDK      | Device          | API Level |
+| Android Studio        | CMake       | NDK      | Device          | API Level |
 |-----------------------|-------------|----------|-----------------|-----------|
 | Jellyfish 2023.3.1    | 3.22.1      | r25c     | Pixel 7 Pro     | 34        |
-| Jellyfish 2023.3.1    | 3.22.1      | r25c     | x86_64 Emulator | 31        |
+| Jellyfish 2023.3.1    | 3.22.1      | r25c     | x86_64 Emulator | 34        |
 
 
 Known Issues

--- a/tutorial01_load_vulkan/app/build.gradle
+++ b/tutorial01_load_vulkan/app/build.gradle
@@ -15,26 +15,26 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
 
     defaultConfig {
         applicationId "com.android.example.vulkan.tutorials.one"
-        minSdkVersion 24
-        targetSdkVersion 31
+        minSdkVersion 26
+        targetSdkVersion 34
 
         versionCode  272
         versionName "1.1.0"
         externalNativeBuild {
             cmake {
-                abiFilters "armeabi-v7a", 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
             }
         }
     }
     externalNativeBuild {
         cmake {
-            version '3.18.1'
+            version '3.22.1'
             path    'src/main/cpp/CMakeLists.txt'
         }
     }
@@ -44,6 +44,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.games:games-activity:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.games:games-activity:1.2.2"
 }

--- a/tutorial01_load_vulkan/build.gradle
+++ b/tutorial01_load_vulkan/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial01_load_vulkan/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial01_load_vulkan/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 24 15:15:23 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorial02_prebuild_layers/README.md
+++ b/tutorial02_prebuild_layers/README.md
@@ -2,20 +2,18 @@
 
 Demonstrate how to use validation layers prebuilt from [Validation layer repo][1]
 
-## Pre-requirement:
----------------
-1. Download prebuilt validation layer android-binaries-*.zip from [Khronos repo][1]
-1. unzip to $this-project-root/vvl-libs
+This sample automatically downloads prebuilt validation layer zip from [Khronos repo][1],
+unzips it, and adds the validation layer library to the project's jniLibs.
 
 ## Added steps from previous example
 1. Use vulkan wrappers in common/vulkan_wrapper directory.
-1. Add the validation layer into gradle build to pack it into apk.
-1. (Optional but nice to have)Confirm the validation layer "VK_LAYER_KHRONOS_validation" is available with `vkEnumerateInstanceLayerProperties()`. 
-1. Enable the validation layer and "VK_EXT_debug_report" when creating instance.
-1. Register debug callback implemented in "VK_EXT_debug_report" with vkCreateDebugReportCallbackEXT(). Note that application could also use "VK_EXT_debug_utils" implemented in the validatio layer.
+1. Add the validation layer into gradle build to pack it into APK.
+1. (Optional but nice to have) Confirm the validation layer `VK_LAYER_KHRONOS_validation` is available with `vkEnumerateInstanceLayerProperties()`. 
+1. Enable the validation layer and `VK_EXT_debug_report` when creating instance.
+1. Register debug callback implemented in `VK_EXT_debug_utils` with `pfnCreateDebugUtilsMessengerEXT()`. Note that on some devices it can use `VK_EXT_debug_report` instead.
 
 # Verification
-Planted error: this sample sets [`VkDeviceQueueCreateInfo::pQueuePriorities`][2](https://github.com/googlesamples/android-vulkan-tutorials/blob/master/tutorial02_prebuild_layers/app/src/main/jni/main.cpp#L190) to nullptr,
+Planted error: this sample sets [`VkDeviceQueueCreateInfo::pQueuePriorities`][2](https://github.com/googlesamples/android-vulkan-tutorials/blob/master/tutorial02_prebuild_layers/app/src/main/jni/main.cpp#L190) to `nullptr`,
 which will trigger validation layers to notify us from registered callback function
 `vkDebugReportCallbackEX_impl();` putting a breakpoint with Android Studio, observe
 the breakpoint being triggered.
@@ -24,6 +22,7 @@ In logcat, you would see the error message like:
 ```
 E/Vulkan-Debug-Message:: Validation -- Validation Error: [ VUID-VkDeviceQueueCreateInfo-pQueuePriorities-parameter ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xd6d720c6 | vkCreateDevice: required parameter pCreateInfo->pQueueCreateInfos[0].pQueuePriorities specified as NULL. The Vulkan spec states: pQueuePriorities must be a valid pointer to an array of queueCount float values (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkDeviceQueueCreateInfo-pQueuePriorities-parameter)
 ```
+
 ## Additional References
 - [Validation layer history][3]
 [1]:https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases/latest

--- a/tutorial02_prebuild_layers/app/build.gradle
+++ b/tutorial02_prebuild_layers/app/build.gradle
@@ -2,29 +2,29 @@ apply plugin: 'com.android.application'
 
 // Download validation layers from
 //     https://github.com/KhronosGroup/Vulkan-ValidationLayers
-ext.vvl_version='1.3.231.1'
+ext.vvl_version='1.3.290.0'
 apply from: 'download_vvl.gradle'
 
 // This project's build scripts follows
 android {
-    compileSdkVersion 33
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
     defaultConfig {
         applicationId "com.android.example.vulkan.tutorials.two"
         minSdkVersion 26
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode  272
         versionName  "1.1.0"
         externalNativeBuild {
             cmake {
-                abiFilters "armeabi-v7a", 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
             }
         }
     }
     externalNativeBuild {
         cmake {
-            version '3.18.1'
+            version '3.22.1'
             path 'src/main/cpp/CMakeLists.txt'
         }
     }

--- a/tutorial02_prebuild_layers/app/download_vvl.gradle
+++ b/tutorial02_prebuild_layers/app/download_vvl.gradle
@@ -16,7 +16,7 @@ apply plugin: 'com.android.application'
  */
 
 // get tjhe validation layer version.
-def VVL_VER = "1.3.231.1"
+def VVL_VER = "1.3.290.0"
 if (ext.has("vvl_version")) {
     VVL_VER = ext.vvl_version
 }
@@ -29,7 +29,7 @@ def VVL_SO_NAME = "libVkLayer_khronos_validation.so"
 
 // download the release zip file to ${VVL_LIB_ROOT}/
 task download {
-    def VVL_ZIP_NAME = "releases/download/sdk-${VVL_VER}/android-binaries-${VVL_VER}.zip"
+    def VVL_ZIP_NAME = "releases/download/vulkan-sdk-${VVL_VER}/android-binaries-${VVL_VER}.zip"
     mkdir "${VVL_LIB_ROOT}"
     def f = new File("${VVL_LIB_ROOT}/android-binaries-${VVL_VER}.zip")
     new URL("${VVL_SITE}/${VVL_ZIP_NAME}")
@@ -42,7 +42,7 @@ task unzip(dependsOn: download, type: Copy) {
     into file("${VVL_JNILIB_DIR}")
 }
 android.sourceSets.main.jniLibs {
-        srcDirs += ["${VVL_JNILIB_DIR}"]
+    srcDirs += ["${VVL_JNILIB_DIR}/android-binaries-${VVL_VER}"]
 }
 
 // add vvl download as an application dependency.

--- a/tutorial02_prebuild_layers/build.gradle
+++ b/tutorial02_prebuild_layers/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial02_prebuild_layers/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial02_prebuild_layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 09 10:29:26 PST 2022
+#Tue Sep 24 15:14:08 TRT 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/tutorial03_traceable_layers/README.md
+++ b/tutorial03_traceable_layers/README.md
@@ -1,43 +1,39 @@
 # Tutorial 03 - traceable_layers
+
 This has the same functionality as [Tutorial 2](../tutorial02_prebuild_layers), but building the validation layers
 from the Khronos Group Validation Layer source code hosted on [the github repo](https://github.com/KhronosGroup/Vulkan-ValidationLayers.git).
-The benefit is:
-- you could trace into validation layers.
-- you could observe the detailed status when validation layer finds issues in your app.
 
-Validation layers are stable now, this should be a good help to developers who likge to know
-more about validation layers inside.
+The benefit is:
+- You can peek/step into validation layers.
+- You can observe the detailed status when validation layer finds issues in your app.
+
+This can be useful for developers who want to know more about validation layers.
 
 # Background
-Layer source status:
-- For NDK version <= r21, there are multiple layers for Android; NDK keeps a snapshot of layer source code and the binaries
-- For NDK22 layers are consolidated into one layer: VkLayer_khronos_validation; NDK keeps a snapshot of layer source code and the binary
-- For NDK version >= r23, layer source and binary are not available anymore.
 
-We recommend developers to get the validation layer source and binary releases directly from
+Building validation layers from sources currently requires NDK r25c or newer.
+
+Developers should get the validation layer source from
 [the github repo](https://github.com/KhronosGroup/Vulkan-ValidationLayers.git).
 
 
 # Build Instructions
-In this sample, the validation layers is wrapped into a gradle library module called "layerlib", it is a dependent module to application
-code(to force it build before app).The validation layer source code needs to be pulled in on command line before building the sample:
+
+In this sample, the validation layers is wrapped into a gradle library module called `layerlib`. The `app`
+module depends on this `layerlib` module.
+
+The validation layer source code needs to be pulled in on command line before building the sample. Steps:
+
 1. cd tutorial03_traceable_layers/layerlib
 2. git clone --recursive https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
-3. cd Vulkan-ValidationLayers/build-android
-4. ./update_external_sources_android.sh --no-build
-    (use the update_external_sources_android.bat for Windows OS)
-5. Now, at this point, open this sample with Android Studio with "Open an Existing Project" option
-6. Build the project, and start debugging(Run > Debug App). It takes about 20 minutes to build layers, so be patient
+3. Now, at this point, open this sample with Android Studio with "Open an Existing Project" option
+4. Build the project, and start debugging (Run > Debug App). It can take 5-10 minutes to build on slower machines.
 
-Once app triggers validation layer assert(embedded on purpose inside this sample in the app), you could see the stack frames
-inside Studio IDE., inside the debug window, you would see all validation layer variables when the app error is validated.
+Once the app triggers validation layer assert (embedded on purpose inside this sample in the app), you can see the stack frames
+in the Android Studio IDE debugger. You can also step into the validation layer, and check the values of all variables.
 
-This sample is not tested on windows, it should work.
-
-## future work
-- Automically pull the source code automatically in gradle, but gradle's 'ndkBuild path' is evaluated before source code pulling,
-hence errors out, need help to get it done.
-- automatically run update_external_sources_android.sh. probably needs a gradle task to do it.
+## Future Work
+- Automically pull the source code automatically in Gradle.
 
 # Screenshot
 ![screenshot](screenshot.png)

--- a/tutorial03_traceable_layers/README.md
+++ b/tutorial03_traceable_layers/README.md
@@ -26,14 +26,16 @@ The validation layer source code needs to be pulled in on command line before bu
 
 1. cd tutorial03_traceable_layers/layerlib
 2. git clone --recursive https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
-3. Now, at this point, open this sample with Android Studio with "Open an Existing Project" option
-4. Build the project, and start debugging (Run > Debug App). It can take 5-10 minutes to build on slower machines.
+3. Make sure the `cmake` binary is on your `PATH` environment variable.
+4. Open this sample with Android Studio with "Open an Existing Project" option
+5. Sync the project with Gradle Files. This can take 3-5 minutes to sync.
+6. Build the project, and start debugging (Run > Debug App). It can take 5-10 minutes to build.
 
 Once the app triggers validation layer assert (embedded on purpose inside this sample in the app), you can see the stack frames
 in the Android Studio IDE debugger. You can also step into the validation layer, and check the values of all variables.
 
 ## Future Work
-- Automically pull the source code automatically in Gradle.
+- Automatically pull the source code automatically in Gradle.
 
 # Screenshot
 ![screenshot](screenshot.png)

--- a/tutorial03_traceable_layers/app/build.gradle
+++ b/tutorial03_traceable_layers/app/build.gradle
@@ -15,16 +15,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
 
     defaultConfig {
         applicationId "com.android.example.vulkan.tutorials.three"
-        minSdkVersion    24
-        targetSdkVersion 31
+        minSdkVersion    26
+        targetSdkVersion 34
         versionCode = 272
         versionName = "1.1.0"
-        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+        ndk.abiFilters 'arm64-v8a', 'x86_64'
         externalNativeBuild.cmake.arguments '-DANDROID_TOOLCHAIN=clang',
                                             '-DANDROID_STL=c++_static'
     }
@@ -34,7 +34,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            version '3.18.1'
+            version '3.22.1'
             path = 'src/main/cpp/CMakeLists.txt'
         }
     }
@@ -45,6 +45,6 @@ android {
 
 dependencies {
     implementation project(path: ':layerlib')
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.games:games-activity:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.games:games-activity:1.2.2"
 }

--- a/tutorial03_traceable_layers/build.gradle
+++ b/tutorial03_traceable_layers/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial03_traceable_layers/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial03_traceable_layers/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 28 22:36:34 PDT 2021
+#Tue Sep 24 15:20:37 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/tutorial03_traceable_layers/layerlib/build.gradle
+++ b/tutorial03_traceable_layers/layerlib/build.gradle
@@ -1,37 +1,28 @@
 apply plugin: 'com.android.library'
 
-/* Build Validation Layer source code in https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
-   Steps:
+/* Steps to setup Vulkan Validation Layers source code:
       1. cd tutorial03_traceable_layers/layerlib
       2. git clone --recursive https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
-      3. cd Vulkan-ValidationLayers/build-android
-      4. ./update_external_sources_android.sh --no-build
-        (use the update_external_sources_android.bat for Windows OS)
-      5. Switch to Studio IDE, sync the project and build etc
+      3. Switch to Studio IDE, sync the project and build etc
  */
 def LAYER_SRC=projectDir.toString() + '/Vulkan-ValidationLayers'
 android {
-    compileSdkVersion 31
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion 31
+        minSdkVersion 26
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
-        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+        ndk.abiFilters 'arm64-v8a', 'x86_64'
         externalNativeBuild {
-            // I could not get ndk-build with Application.mk, so for now we need to
-            // pass all settings in the Application.mk as command line parameters to ndk-build.
-            ndkBuild.arguments "NDK_MODULE_PATH=${LAYER_SRC}/build-android",
-                               "NDK_PROJECT_PATH=${LAYER_SRC}/build-android",
-                               'APP_MODULES=VkLayer_khronos_validation',
-                               'APP_PLATFORM=android-26',
-                               'NDK_TOOLCHAIN_VERSION=clang',
-                               'APP_STL=c++_static',
-                               'NDK_DEBUG=1', 'APP_OPTIM=debug',
-                               '-j8'   // set up the right cpu count, should but do not know
-                                       // how to get it from org.gradle.workers.max
+            cmake {
+                // Flags taken from Vulkan Validation Layers build docs for Android at:
+                // https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/BUILD.md#building-for-android
+                arguments.add("-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=NO")
+                arguments.add("-DUPDATE_DEPS=ON")
+            }
         }
     }
 
@@ -40,7 +31,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     externalNativeBuild {
-        ndkBuild.path "${LAYER_SRC}/build-android/jni/Android.mk"
+        cmake {
+            path "${LAYER_SRC}/CMakeLists.txt"
+            version "3.22.1"
+        }
     }
     buildTypes {
         release {

--- a/tutorial04_first_window/app/build.gradle
+++ b/tutorial04_first_window/app/build.gradle
@@ -15,26 +15,26 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
 
     defaultConfig {
         applicationId  "com.android.example.vulkan.tutorials.four"
-        minSdkVersion     24
-        targetSdkVersion  31
+        minSdkVersion     26
+        targetSdkVersion  34
         versionCode  272
         versionName  "1.1.0"
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
     }
 
     externalNativeBuild {
         cmake {
-            version '3.18.1'
+            version '3.22.1'
             path    'src/main/cpp/CMakeLists.txt'
         }
     }
@@ -44,6 +44,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.games:games-activity:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.games:games-activity:1.2.2"
 }

--- a/tutorial04_first_window/build.gradle
+++ b/tutorial04_first_window/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorial04_first_window/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial04_first_window/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 24 16:01:38 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorial05_triangle/app/build.gradle
+++ b/tutorial05_triangle/app/build.gradle
@@ -15,13 +15,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
-    ndkVersion "23.1.7779620"
+    compileSdkVersion 34
+    ndkVersion "25.2.9519653"
 
     defaultConfig {
         applicationId  "com.android.example.vulkan.tutorials.five"
-        minSdkVersion    24
-        targetSdkVersion 31
+        minSdkVersion    26
+        targetSdkVersion 34
         versionCode 272
         versionName "1.1.0"
 
@@ -34,14 +34,14 @@ android {
         }
         externalNativeBuild {
             cmake {
-                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a', 'x86_64'
                 arguments '-DANDROID_TOOLCHAIN=clang', '-DANDROID_STL=c++_static'
             }
         }
     }
     externalNativeBuild {
         cmake {
-            version '3.18.1'
+            version '3.22.1'
             path 'src/main/cpp/CMakeLists.txt'
         }
     }
@@ -50,6 +50,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.games:games-activity:1.1.0"
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.games:games-activity:1.2.2"
 }

--- a/tutorial05_triangle/build.gradle
+++ b/tutorial05_triangle/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorial05_triangle/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial05_triangle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 24 16:07:25 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorial06_texture/README.md
+++ b/tutorial06_texture/README.md
@@ -14,7 +14,7 @@ Pre-build shaderc with:
 ```
  mkdir -p  app/src/main/cpp/shaderc
  cd app/src/main/cpp/shaderc
- ${ndk_dir}/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=${ANDROID_STL} APP_ABI:=all APP_PLATFORM:=${your-minSdkLevel} libshaderc_combined
+ ${ndk_dir}/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=${ANDROID_STL} APP_ABI:=arm64-v8a,x86_64 APP_PLATFORM:=${your-minSdkLevel} libshaderc_combined
 ```
 Screenshot
 ------------

--- a/tutorial06_texture/README.md
+++ b/tutorial06_texture/README.md
@@ -14,8 +14,33 @@ Pre-build shaderc with:
 ```
  mkdir -p  app/src/main/cpp/shaderc
  cd app/src/main/cpp/shaderc
- ${ndk_dir}/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=${ANDROID_STL} APP_ABI:=arm64-v8a,x86_64 APP_PLATFORM:=${your-minSdkLevel} libshaderc_combined
+ ${ANDROID_NDK}/ndk-build -j 10 NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=${ANDROID_STL} APP_ABI:=arm64-v8a,x86_64 APP_PLATFORM:=${APP_PLATFORM} libshaderc_combined
 ```
+
+Replace the `ANDROID_NDK`, `ANDROID_STL`, and `APP_PLATFORM` with appropriate values, such as the
+path to NDK r25.1, `c++_static`, and `latest`.
+
+This build step can take 3-5 minutes. If you only care about a single ABI, setting `APP_ABI`
+accordingly will reduce this build time by half.
+
 Screenshot
 ------------
 <img src="./Tutorial_6_Screenshot.png" height="400px">
+
+
+Known Issues
+------------
+
+On Windows, you may encounter the following build error during `shaderc` compilation:
+
+```
+$ANDROID_NDK/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-ar.exe: error: script line 1: unknown command: "create
+```
+
+In this case, edit the following generated files and remove all copies of double quotes (i.e., the
+'"' char):
+
+```
+tutorial06_texture/app/src/main/cpp/shaderc/obj/local/arm64-v8a/combine.ar
+tutorial06_texture/app/src/main/cpp/shaderc/obj/local/x86_64/combine.ar
+```

--- a/tutorial06_texture/app/build.gradle
+++ b/tutorial06_texture/app/build.gradle
@@ -15,16 +15,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
-    ndkVersion '25.1.8937393'
+    compileSdkVersion 34
+    ndkVersion '25.2.9519653'
     defaultConfig {
         applicationId "com.android.example.vulkan.tutorials.six"
         minSdkVersion 26
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 272
         versionName "1.1.0"
 
-        ndk.abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+        ndk.abiFilters 'arm64-v8a', 'x86_64'
         externalNativeBuild {
             cmake.arguments '-DANDROID_TOOLCHAIN=clang',
                             '-DANDROID_STL=c++_static',

--- a/tutorial06_texture/app/src/main/cpp/CMakeLists.txt
+++ b/tutorial06_texture/app/src/main/cpp/CMakeLists.txt
@@ -46,13 +46,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
     -std=c++11 -Wall -Wno-unused-variable \
     -Wno-delete-non-virtual-dtor -DVK_USE_PLATFORM_ANDROID_KHR")
 
-if (${ANDROID_ABI} STREQUAL "armeabi-v7a")
-    set(CMAKE_CXX_FLAGS} "${CMAKE_CXX_FLAGS} \
-        -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -mfloat-abi=hard")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} \
-        -Wl,--no-warn-mismatch")
-endif()
-
 # requirement: prebuild shaderc with:
 #  cd  ${CMAKE_CURRENT_SOURCE_DIR} && mkdir -p shaderc && cd shaderc
 #  ${ANDROID_NDK}/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=all APP_ABI:=all APP_PLATFORM:=android-26 libshaderc_combined

--- a/tutorial06_texture/app/src/main/cpp/CMakeLists.txt
+++ b/tutorial06_texture/app/src/main/cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 
 # requirement: prebuild shaderc with:
 #  cd  ${CMAKE_CURRENT_SOURCE_DIR} && mkdir -p shaderc && cd shaderc
-#  ${ANDROID_NDK}/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=all APP_ABI:=all APP_PLATFORM:=android-26 libshaderc_combined
+#  ${ANDROID_NDK}/ndk-build -j 10 NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=${ANDROID_NDK}/sources/third_party/shaderc/Android.mk APP_STL:=all APP_ABI:=all APP_PLATFORM:=android-26 libshaderc_combined
 add_library(shaderc STATIC IMPORTED)
 set_target_properties(shaderc PROPERTIES IMPORTED_LOCATION
     ${CMAKE_CURRENT_SOURCE_DIR}/shaderc/libs/${ANDROID_STL}/${ANDROID_ABI}/libshaderc.a)

--- a/tutorial06_texture/build.gradle
+++ b/tutorial06_texture/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorial06_texture/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorial06_texture/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 24 16:11:24 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR modernizes all samples to use relatively newer versions for most major dependencies. It uses the following versions:

AGP=7.4.2
Gradle=7.5
NDK=r25c
CMake=3.22.1
minSdkVersion=26
compileSdkVersion/targetSdkVersion=34
ABIs=arm64,x86_64 only
Validation Layers prebuilts=1.3.290.0

Also slightly bumps appcompat and game-activity dependency versions.

This change also updates all README files, and the test matrix used to verify all 6 tutorials.

